### PR TITLE
fix(tokens): generate tokens files with ts instead js

### DIFF
--- a/packages/tokens/scripts/generate-tokens.ts
+++ b/packages/tokens/scripts/generate-tokens.ts
@@ -46,7 +46,7 @@ function processCssFileByTokenPrefix(cssFilePath: string, prefix: string) {
   const cssContent = fs.readFileSync(cssFilePath, 'utf8')
   const tokens = extractTokensFromCss(cssContent, prefix)
 
-  const outputFileName = `${prefix}.js`
+  const outputFileName = `${prefix}.ts`
   const outputFilePath = path.join(OUTPUT_DIR, outputFileName)
 
   generateJavaScriptFile(tokens, outputFilePath)


### PR DESCRIPTION
## Infos

[Task](https://juntossomosmais.monday.com/boards/950575490/pulses/4696290448)

#### What is being delivered?

- Generate tokens files with `ts` instead `js` because `js` files was being resolved as `any`

#### What impacts?

- Tokens build

#### Reversal plan

Reset commit to the previous version [b8fc84b](https://github.com/juntossomosmais/atomium/commit/da861d287f2a478086de455a3f888de94ab677ec)

#### Evidences

![image](https://github.com/juntossomosmais/atomium/assets/75763403/34c50836-6f2d-45d7-ab9f-7e771fcc936b)

___

<img width="412" alt="image" src="https://github.com/juntossomosmais/atomium/assets/75763403/4833d85c-8b6a-4074-a4e8-d8cf89beddd8">

