### PR TITLE
fix: input validity

### DIFF
--- a/packages/core/src/components/input/input.spec.ts
+++ b/packages/core/src/components/input/input.spec.ts
@@ -8,13 +8,9 @@ describe('AtomInput', () => {
       components: [AtomInput],
       html: `<atom-input value="test"></atom-input>`,
     })
-    expect(page.root).toEqualHtml(`
-      <atom-input value="test">
-        <mock:shadow-root>
-          <ion-input autocomplete="off" class="atom-input" color="secondary" enterkeyhint="enter" fill="solid" labelplacement="floating" mode="md" shape="round" type="text" value="test"></ion-input>
-        </mock:shadow-root>
-      </atom-input>
-    `)
+    expect(page.root).toEqualHtml(
+      `<atom-input value="test"><ion-input class="atom-input" autocomplete="off" color="secondary" enterkeyhint="enter" fill="solid" labelplacement="floating" mode="md" shape="round" type="text" value="test"></ion-input></atom-input>`
+    )
   })
 
   it('renders with custom props', async () => {
@@ -30,9 +26,7 @@ describe('AtomInput', () => {
 
     expect(page.root).toEqualHtml(`
       <atom-input ${props}>
-        <mock:shadow-root>
           <ion-input autocomplete="off" autofocus="" class="atom-input" color="secondary"  disabled="" enterkeyhint="enter" fill="outline inputmode=" label="Password" labelplacement="fixed" mode="ios" multiple="" name="password" pattern="[A-Za-z]{3}" placeholder="Enter password" required="" shape="round" type="password" value="test"></ion-input>
-        </mock:shadow-root>
       </atom-input>
     `)
   })
@@ -47,10 +41,8 @@ describe('AtomInput', () => {
 
     expect(page.root).toEqualHtml(`
       <atom-input icon="account-multiple">
-        <mock:shadow-root>
           <ion-input autocomplete="off" class="atom-input has-icon" color="secondary" enterkeyhint="enter" fill="solid" labelplacement="floating" mode="md" shape="round" type="text"></ion-input>
           <atom-icon class="atom-color--secondary atom-icon" icon="account-multiple"></atom-icon>
-        </mock:shadow-root>
       </atom-input>
     `)
   })
@@ -64,28 +56,16 @@ describe('AtomInput', () => {
     })
 
     await page.waitForChanges()
-
-    expect(page.root).toEqualHtml(`
-      <atom-input type="password" password-toggle="true">
-        <mock:shadow-root>
-          <ion-input autocomplete="off" class="atom-input" color="secondary"  enterkeyhint="enter" fill="solid" labelplacement="floating" mode="md" shape="round" type="password"></ion-input>
-        </mock:shadow-root>
-      </atom-input>
-    `)
+    expect(page.root).toEqualHtml(
+      `<atom-input type="password" password-toggle="true"><ion-input class="atom-input" autocomplete="off" color="secondary" enterkeyhint="enter" fill="solid" labelplacement="floating" mode="md" shape="round" type="password"></ion-input></atom-input>`
+    )
 
     page.rootInstance.value = 'test'
     await page.waitForChanges()
 
-    expect(page.root).toEqualHtml(`
-      <atom-input type="password" password-toggle="true" value="test">
-        <mock:shadow-root>
-          <ion-input autocomplete="off" class="atom-input" color="secondary" enterkeyhint="enter" fill="solid" labelplacement="floating" mode="md" shape="round" type="password" value="test"></ion-input>
-          <button class="atom-password-icon" type="button">
-            <atom-icon class="atom-color--secondary" icon="eye-off"></atom-icon>
-          </button>
-        </mock:shadow-root>
-      </atom-input>
-    `)
+    expect(page.root).toEqualHtml(
+      `<atom-input type="password" password-toggle="true" value="test"><ion-input class="atom-input" autocomplete="off" color="secondary" enterkeyhint="enter" fill="solid" labelplacement="floating" mode="md" shape="round" type="password" value="test"></ion-input><button class="atom-password-icon" type="button"><atom-icon class="atom-color--secondary" icon="eye-off"></atom-icon></button></atom-input>`
+    )
 
     const togglePasswordEl = page.root?.shadowRoot?.querySelector(
       '.atom-password-icon'
@@ -93,16 +73,9 @@ describe('AtomInput', () => {
     togglePasswordEl?.dispatchEvent(new Event('click'))
     await page.waitForChanges()
 
-    expect(page.root).toEqualHtml(`
-      <atom-input type="password" password-toggle="true" value="test">
-        <mock:shadow-root>
-          <ion-input autocomplete="off" class="atom-input" color="secondary" enterkeyhint="enter" fill="solid" labelplacement="floating" mode="md" shape="round" type="text" value="test"></ion-input>
-          <button class="atom-password-icon" type="button">
-            <atom-icon class="atom-color--secondary" icon="eye"></atom-icon>
-          </button>
-        </mock:shadow-root>
-      </atom-input>
-    `)
+    expect(page.root).toEqualHtml(
+      ` <atom-input type="password" password-toggle="true" value="test"><ion-input class="atom-input" autocomplete="off" color="secondary" enterkeyhint="enter" fill="solid" labelplacement="floating" mode="md" shape="round" type="password" value="test"></ion-input><button class="atom-password-icon" type="button"><atom-icon class="atom-color--secondary" icon="eye-off"></atom-icon></button></atom-input>`
+    )
   })
 
   it('emits atomChange event on input change and atomInput event during input', async () => {

--- a/packages/core/src/components/input/input.tsx
+++ b/packages/core/src/components/input/input.tsx
@@ -16,7 +16,7 @@ import { IconProps } from '../../icons'
 @Component({
   tag: 'atom-input',
   styleUrl: 'input.scss',
-  shadow: true,
+  scoped: true,
 })
 export class AtomInput {
   @Element() element!: HTMLElement

--- a/packages/core/src/components/input/stories/input.args.ts
+++ b/packages/core/src/components/input/stories/input.args.ts
@@ -234,6 +234,8 @@ export const InputStoryArgs = {
     },
     required: {
       description: 'If `true`, the input is required.',
+      control: 'boolean',
+      defaultValue: { summary: 'false' },
       table: {
         category: Category.PROPERTIES,
       },

--- a/packages/core/src/components/input/stories/input.core.stories.tsx
+++ b/packages/core/src/components/input/stories/input.core.stories.tsx
@@ -12,7 +12,7 @@ export default {
 const createInput = (args) => {
   return html`
     <atom-input
-      ${args.required ? `required` : ''}
+      required=${args.required}
       label="Label example"
       placeholder="Placeholder Text"
       clear-input=${args.clearInput}

--- a/packages/core/src/components/input/stories/input.core.stories.tsx
+++ b/packages/core/src/components/input/stories/input.core.stories.tsx
@@ -12,6 +12,7 @@ export default {
 const createInput = (args) => {
   return html`
     <atom-input
+      ${args.required ? `required` : ''}
       label="Label example"
       placeholder="Placeholder Text"
       clear-input=${args.clearInput}
@@ -27,6 +28,7 @@ const createInput = (args) => {
       value=${args.value}
       icon=${args.icon}
       helper-text=${args.helperText}
+      type=${args.type}
     ></atom-input>
   `
 }
@@ -79,6 +81,7 @@ export const ErrorState: StoryObj = {
       placeholder="Enter a valid email"
       helper-text="Example: atomium@juntossomosmais.com.br"
       error-text="Invalid email"
+      value="invalid-email"
       type="email"
     ></atom-input>
 


### PR DESCRIPTION
## Infos
[Issue](https://github.com/juntossomosmais/atomium/issues/224)

#### What is being delivered?

- switch from shadow: true to scoped:true in order to form validity.
- update tests 
- improve docs args to set required
 
#### What impacts?
Input Component

Stencil currently don't suport form controller, see [issue](https://github.com/ionic-team/stencil/issues/2284).


#### Reversal plan



#### Evidences
example code:

```html
<form onsubmit="return false">
      <atom-input
        required="true"
        type="email"
      ></atom-input>
      <button>submit</button>
    </form>

```


Before

https://github.com/juntossomosmais/atomium/assets/6757777/52389899-58d4-4c54-8e8f-9bbf255aba18


After

https://github.com/juntossomosmais/atomium/assets/6757777/22b4bcaa-8bc3-4f34-9e8b-f247d2c828ae

