### PR TITLE
chore: add extra option to apply use on vite

### DIFF
--- a/packages/core/stencil.config.ts
+++ b/packages/core/stencil.config.ts
@@ -13,6 +13,9 @@ export const config: Config = {
       injectGlobalPaths: ['../../node_modules/@ionic/core/css/core.css'],
     }),
   ],
+  extras: {
+    enableImportInjection: true,
+  },
   globalScript: 'src/global/global.ts',
   globalStyle: 'src/global/global.scss',
   outputTargets: [


### PR DESCRIPTION
## Infos

[Task](https://juntossomosmais.monday.com/boards/XXX/pulses/XXX)

#### What is being delivered?

Add use of injection imports for vite bundlers.

#### What impacts?

Build and config of modules.

#### Reversal plan

Reset to the last commit and release of stable version.

#### Evidences

Doc stencil: https://stenciljs.com/docs/config-extras#enableimportinjection

Tests in another projects 
![React stencil atomium](https://github.com/juntossomosmais/atomium/assets/51102351/c59b69a6-0a3f-4d4a-9c8a-f9ed43a2842d)
![image](https://github.com/juntossomosmais/atomium/assets/51102351/745655b8-7a6a-437b-a543-eff0678d1c07)

Media(images, gifs or videos) that shows the result of your work.
