### PR TITLE
fix: use line-height in badge

### DIFF
--- a/packages/core/src/components/badge/badge.scss
+++ b/packages/core/src/components/badge/badge.scss
@@ -1,3 +1,7 @@
+:host {
+  line-height: 0;
+}
+
 .atom-badge {
   border-radius: var(--border-radius-medium);
   color: var(--color-neutral-white);

--- a/packages/core/src/components/badge/badge.tsx
+++ b/packages/core/src/components/badge/badge.tsx
@@ -1,4 +1,4 @@
-import { Component, Prop, h } from '@stencil/core'
+import { Component, Host, Prop, h } from '@stencil/core'
 
 @Component({
   tag: 'atom-badge',
@@ -18,9 +18,11 @@ export class AtomBadge {
 
   render() {
     return (
-      <ion-badge color={this.type} class="atom-badge">
-        <slot />
-      </ion-badge>
+      <Host>
+        <ion-badge color={this.type} class="atom-badge">
+          <slot />
+        </ion-badge>
+      </Host>
     )
   }
 }


### PR DESCRIPTION
## Infos

[Task](https://juntossomosmais.monday.com/boards/XXX/pulses/XXX)

#### What is being delivered?

Adding propriety `line-height: 0` in `Host` of  `badge` component, because the component needs to conform to the context of the container it's embedded in.

#### What impacts?

[Component badge](https://github.com/juntossomosmais/atomium/pull/239)

#### Reversal plan

Reset commit to the previous version.

#### Evidences

Before
![image](https://github.com/juntossomosmais/atomium/assets/59345698/51d88845-a919-48c4-b5e4-7e3388889b4b)

After
![image](https://github.com/juntossomosmais/atomium/assets/59345698/411f1681-1e7f-4744-92ed-770b862faa17)

