### PR TITLE
fix(core): add stop propagation to avoid button to emit event twice

### DIFF
--- a/packages/core/src/components/button/button.tsx
+++ b/packages/core/src/components/button/button.tsx
@@ -33,13 +33,14 @@ export class AtomButton {
 
   @Element() element: HTMLElement
 
-  formFunctions = {
+  private formFunctions = {
     reset: 'reset',
     submit: 'requestSubmit',
   }
 
   private handleClick = (event) => {
     event.preventDefault()
+    event.stopPropagation()
 
     if (this.loading || this.disabled) return
     if (this.type === 'button') {


### PR DESCRIPTION
## Infos
 
#### What is being delivered?

- Add `stop.propagation` inside `handleClick` to avoid emit event twice

#### What impacts?

Button was emitting click events twice
<img width="592" alt="image" src="https://github.com/juntossomosmais/atomium/assets/3603793/0a205223-de4a-4fc7-a859-92fc539da2b1">

For now are emitting just once
<img width="579" alt="image" src="https://github.com/juntossomosmais/atomium/assets/3603793/9edc04e1-b1ef-443c-be08-f36952020a46">
