### PR TITLE
docs: fix wrong command

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ npm test
 npm run build
 
 ## Build Storybook
-npm run storybook:build
+npm run docs:build
 ```
 
 ## Main folder structure


### PR DESCRIPTION
## Infos

#### What is being delivered?

- change `storybook:build` to `docs:build`

#### What impacts?

Resolves #285 
