### PR TITLE
fix(core): add specificity to input border-radius class

### DIFF
--- a/packages/core/src/components/input/input.scss
+++ b/packages/core/src/components/input/input.scss
@@ -40,7 +40,7 @@
     }
   }
 
-  &.input-shape-round {
+  &.input-fill-outline.input-shape-round.sc-ion-input-md-h {
     --border-radius: var(--border-radius-medium);
   }
 


### PR DESCRIPTION
## Infos

[Task](https://juntossomosmais.monday.com/boards/1756815464/pulses/5277352428)

#### What is being delivered?

Adds a specificier class to the input border-radius styles so it can be rendered correctly on react apps. 

#### What impacts?

React projects can get the the input with correct border-radius from atomium tokens.

#### Reversal plan

https://github.com/juntossomosmais/web-customer-typescript/wiki/Processo-para-reverter-Deploy

#### Evidences

![image](https://github.com/juntossomosmais/atomium/assets/31256653/a68c0701-6c06-452a-80c8-649c61259443)
