### PR TITLE
fix(atom-select): add possibility to pass default value

### DIFF
--- a/packages/core/src/components/select/select.spec.ts
+++ b/packages/core/src/components/select/select.spec.ts
@@ -2,7 +2,12 @@ import { newSpecPage } from '@stencil/core/testing'
 
 import { AtomSelect } from './select'
 
-const optionsMock = [
+const optionsMock: {
+  value: string
+  selected?: boolean
+  disabled?: boolean
+  label?: string
+}[] = [
   { value: 'apple', selected: true },
   { value: 'banana', disabled: true },
   { value: 'orange' },
@@ -45,6 +50,33 @@ describe('AtomSelect', () => {
         <mock:shadow-root>
           <ion-select class="atom-select" color="secondary" fill="solid" interface="popover" label-placement="stacked" mode="md" shape="round" value="apple">
             <ion-select-option value="apple">apple</ion-select-option>
+            <ion-select-option value="banana" disabled>banana</ion-select-option>
+            <ion-select-option value="orange">orange</ion-select-option>
+          </ion-select>
+        </mock:shadow-root>
+      </atom-select>
+    `)
+  })
+
+  it('should render with custom label', async () => {
+    const page = await newSpecPage({
+      components: [AtomSelect],
+      html: '<atom-select />',
+    })
+
+    const withLabel = {
+      value: 'apple',
+      label: 'fake apple',
+    }
+
+    page.rootInstance.options = [withLabel, ...optionsMock.slice(1)]
+    await page.waitForChanges()
+
+    expect(page.root).toEqualHtml(`
+      <atom-select >
+        <mock:shadow-root>
+          <ion-select class="atom-select" color="secondary" fill="solid" interface="popover" label-placement="stacked" mode="md" shape="round">
+            <ion-select-option value="apple">fake apple</ion-select-option>
             <ion-select-option value="banana" disabled>banana</ion-select-option>
             <ion-select-option value="orange">orange</ion-select-option>
           </ion-select>

--- a/packages/core/src/components/select/select.spec.ts
+++ b/packages/core/src/components/select/select.spec.ts
@@ -1,4 +1,5 @@
 import { newSpecPage } from '@stencil/core/testing'
+
 import { AtomSelect } from './select'
 
 const optionsMock = [
@@ -29,6 +30,29 @@ describe('AtomSelect', () => {
       </atom-select>
     `)
   })
+
+  it('should render with selected value', async () => {
+    const page = await newSpecPage({
+      components: [AtomSelect],
+      html: '<atom-select value="apple" />',
+    })
+
+    page.rootInstance.options = optionsMock
+    await page.waitForChanges()
+
+    expect(page.root).toEqualHtml(`
+      <atom-select value="apple">
+        <mock:shadow-root>
+          <ion-select class="atom-select" color="secondary" fill="solid" interface="popover" label-placement="stacked" mode="md" shape="round" value="apple">
+            <ion-select-option value="apple">apple</ion-select-option>
+            <ion-select-option value="banana" disabled>banana</ion-select-option>
+            <ion-select-option value="orange">orange</ion-select-option>
+          </ion-select>
+        </mock:shadow-root>
+      </atom-select>
+    `)
+  })
+
   it('renders with all props', async () => {
     const page = await newSpecPage({
       components: [AtomSelect],

--- a/packages/core/src/components/select/select.tsx
+++ b/packages/core/src/components/select/select.tsx
@@ -37,6 +37,7 @@ export class AtomSelect {
   @Prop({ mutable: true }) options: Array<{
     id: string
     value: string
+    label?: string
     selected?: boolean
     disabled?: boolean
   }> = []
@@ -130,7 +131,7 @@ export class AtomSelect {
               disabled={option.disabled}
               key={option.id}
             >
-              {option.value}
+              {option?.label || option.value}
             </ion-select-option>
           ))}
         </ion-select>

--- a/packages/core/src/components/select/select.tsx
+++ b/packages/core/src/components/select/select.tsx
@@ -113,6 +113,7 @@ export class AtomSelect {
           multiple={this.multiple}
           color={this.color}
           mode={this.mode}
+          value={this.value}
           tabindex={this.readonly && '-1'}
           aria-disabled={this.readonly}
           onIonChange={this.handleChange}

--- a/packages/core/src/components/select/stories/select.args.ts
+++ b/packages/core/src/components/select/stories/select.args.ts
@@ -1,6 +1,5 @@
-import { withActions } from '@storybook/addon-actions/decorator'
-
 import { Category } from '@atomium/storybook-utils/enums/table'
+import { withActions } from '@storybook/addon-actions/decorator'
 
 export const SelectStoryArgs = {
   parameters: {
@@ -84,6 +83,7 @@ export const SelectStoryArgs = {
       },
     },
     value: {
+      control: 'text',
       description: 'The value of native select',
       table: {
         category: Category.PROPERTIES,

--- a/packages/core/src/components/select/stories/select.core.stories.tsx
+++ b/packages/core/src/components/select/stories/select.core.stories.tsx
@@ -34,7 +34,13 @@ const createSelect = (args) => {
             { id: '1', value: 'Red', disabled: false },
             { id: '2', value: 'Green', disabled: false },
             { id: '3', value: 'Blue', disabled: false },
-            { id: '4', value: 'Disabled example', disabled: true },
+            {
+              id: '4',
+              value: 'nice_blue',
+              disabled: false,
+              label: 'Nice Blue',
+            },
+            { id: '5', value: 'Disabled example', disabled: true },
           ]
 
           atomSelect.addEventListener('atomChange', (event) => {

--- a/packages/core/src/components/select/stories/select.core.stories.tsx
+++ b/packages/core/src/components/select/stories/select.core.stories.tsx
@@ -1,5 +1,4 @@
 import { Meta, StoryObj } from '@storybook/web-components'
-
 import { html } from 'lit'
 
 import { SelectComponentArgs, SelectStoryArgs } from './select.args'
@@ -19,6 +18,7 @@ const createSelect = (args) => {
       readonly=${args.readonly}
       multiple=${args.multiple}
       label=${args.label}
+      value=${args.value}
       helper-text=${args.helperText}
       error-text=${args.errorText}
       icon=${args.icon}

--- a/packages/core/src/components/select/stories/select.react.stories.tsx
+++ b/packages/core/src/components/select/stories/select.react.stories.tsx
@@ -1,7 +1,6 @@
+import { AtomSelect } from '@juntossomosmais/atomium/react'
 import { Meta, StoryObj } from '@storybook/react'
 import React from 'react'
-
-import { AtomSelect } from '@juntossomosmais/atomium/react'
 
 import { SelectComponentArgs, SelectStoryArgs } from './select.args'
 
@@ -24,6 +23,7 @@ const createSelect = (args) => (
     error-text={args.errorText}
     icon={args.icon}
     mode={args.mode}
+    value={args.value}
     options={[
       { id: '1', value: 'Red', disabled: false },
       { id: '2', value: 'Green', disabled: false },

--- a/packages/core/src/components/select/stories/select.react.stories.tsx
+++ b/packages/core/src/components/select/stories/select.react.stories.tsx
@@ -28,7 +28,8 @@ const createSelect = (args) => (
       { id: '1', value: 'Red', disabled: false },
       { id: '2', value: 'Green', disabled: false },
       { id: '3', value: 'Blue', disabled: false },
-      { id: '4', value: 'Disabled example', disabled: true },
+      { id: '4', value: 'nice_blue', disabled: false, label: 'Nice Blue' },
+      { id: '5', value: 'Disabled example', disabled: true },
     ]}
   />
 )


### PR DESCRIPTION
## Infos

[Task](https://juntossomosmais.monday.com/boards/1521247929/pulses/5568097271)

#### What is being delivered?

Possibility to pass default value for Atom Select and allow to pass label in options object.

#### What impacts?

- Atom-Select

#### Reversal plan

Revert to the previous stable release.

#### Evidences

https://github.com/juntossomosmais/atomium/assets/54173994/e2512184-112c-40a8-8c0b-1aadd48e808a

