### PR TITLE
fix(core): add watch decorator for value prop

### DIFF
--- a/packages/core/src/components/input/input.tsx
+++ b/packages/core/src/components/input/input.tsx
@@ -8,6 +8,7 @@ import {
   Host,
   Method,
   Prop,
+  Watch,
   h,
 } from '@stencil/core'
 
@@ -120,12 +121,19 @@ export class AtomInput {
 
   private handleChange: IonTypes.IonInput['onIonChange'] = (event) => {
     const value = event.target.value
+
     this.value = value
     this.atomChange.emit(String(value))
   }
 
+  @Watch('value')
+  watchValueHandler(newValue: string) {
+    this.atomChange.emit(String(newValue))
+  }
+
   private handleInput: IonTypes.IonInput['onIonInput'] = (event) => {
     const value = event.target.value
+
     this.value = value
     this.atomInput.emit(String(value))
   }
@@ -144,7 +152,7 @@ export class AtomInput {
     return (
       <Host>
         <ion-input
-          ref={(el) => (this.inputEl = el as HTMLIonInputElement)}
+          ref={(el) => (this.inputEl = el)}
           class={{
             'atom-input': true,
             'ion-invalid ion-touched': this.hasError,

--- a/packages/core/src/components/textarea/textarea.tsx
+++ b/packages/core/src/components/textarea/textarea.tsx
@@ -8,6 +8,7 @@ import {
   Host,
   Method,
   Prop,
+  Watch,
   h,
 } from '@stencil/core'
 
@@ -116,14 +117,21 @@ export class AtomTextarea {
     this.textareaEl.removeEventListener('ionFocus', this.handleFocus)
   }
 
+  @Watch('value')
+  watchValueHandler(newValue: string) {
+    this.atomChange.emit(String(newValue))
+  }
+
   private handleChange: IonTypes.IonTextarea['onIonChange'] = (event) => {
     const value = event.target.value
+
     this.value = value
     this.atomChange.emit(String(value))
   }
 
   private handleInput: IonTypes.IonTextarea['onIonInput'] = (event) => {
     const value = event.target.value
+
     this.value = value
     this.atomInput.emit(String(value))
   }


### PR DESCRIPTION
## Infos

[Task](https://juntossomosmais.monday.com/boards/1756815464/pulses/5277352428)

#### What is being delivered?

Added `Watch` decorator and `watchValueHandler` method for right reactivity behavior with onAtomChange prop. 

#### What impacts?

The prop onAtomChange runs on every value update while typing on react applications. 

#### Reversal plan

[Describe which plan we should follow if this delivery has to be reversed.](https://login.microsoftonline.com/49158df8-04df-4db2-a1ae-ee3949ca3984/oauth2/authorize?client%5Fid=00000003%2D0000%2D0ff1%2Dce00%2D000000000000&response%5Fmode=form%5Fpost&response%5Ftype=code%20id%5Ftoken&resource=00000003%2D0000%2D0ff1%2Dce00%2D000000000000&scope=openid&nonce=AC2D47141A613BA5C1B6092D4707302171E1DA38D8662F3B%2DBDF23000C02955542D2DAF0DFBC9EC27F263CFC1C00238D3ABB4772C8CB9B8CD&redirect%5Furi=https%3A%2F%2Fvotorantimindustrial%2Esharepoint%2Ecom%2F%5Fforms%2Fdefault%2Easpx&state=OD0w&claims=%7B%22id%5Ftoken%22%3A%7B%22xms%5Fcc%22%3A%7B%22values%22%3A%5B%22CP1%22%5D%7D%7D%7D&wsucxt=1&cobrandid=11bd8083%2D87e0%2D41b5%2Dbb78%2D0bc43c8a8e8a&client%2Drequest%2Did=73f0f2a0%2D803b%2D4000%2D7fb2%2D81ec3f5bef20)

#### Evidences

