### PR TITLE
fix(core): add more specific has-icon class

### DIFF
--- a/packages/core/src/components/input/input.scss
+++ b/packages/core/src/components/input/input.scss
@@ -42,10 +42,13 @@
 
   &.input-fill-outline.input-shape-round.sc-ion-input-md-h {
     --border-radius: var(--border-radius-medium);
+
+    &.has-icon {
+      --padding-start: var(--atom-icon-grid);
+    }
   }
 
-  &.has-icon,
-  &.has-icon.input-fill-outline.input-shape-round.sc-ion-input-md-h {
+  &.has-icon {
     --padding-start: var(--atom-icon-grid);
     z-index: var(--zindex-10);
   }

--- a/packages/core/src/components/input/input.scss
+++ b/packages/core/src/components/input/input.scss
@@ -44,6 +44,7 @@
     --border-radius: var(--border-radius-medium);
   }
 
+  &.has-icon,
   &.has-icon.input-fill-outline.input-shape-round.sc-ion-input-md-h {
     --padding-start: var(--atom-icon-grid);
     z-index: var(--zindex-10);

--- a/packages/core/src/components/input/input.scss
+++ b/packages/core/src/components/input/input.scss
@@ -44,7 +44,7 @@
     --border-radius: var(--border-radius-medium);
   }
 
-  &.has-icon {
+  &.has-icon.input-fill-outline.input-shape-round.sc-ion-input-md-h {
     --padding-start: var(--atom-icon-grid);
     z-index: var(--zindex-10);
   }


### PR DESCRIPTION
## Infos

[Task](https://juntossomosmais.monday.com/boards/1756815464/pulses/5277352428)

#### What is being delivered?

Add more specific class to has-icon class so the input can have the same space between the icon and the type area on both fill styles.

#### What impacts?

Both fill styles will have the same space between the icon and the type area.

#### Reversal plan

Describe which plan we should follow if this delivery has to be reversed.

#### Evidences

Before:
![image](https://github.com/juntossomosmais/atomium/assets/31256653/2929eaec-4ed3-43bb-b07d-d641e7d7be70)
![image](https://github.com/juntossomosmais/atomium/assets/31256653/41e8e7cf-2ca4-4eef-8aef-25b1772e7e99)

After:
![image](https://github.com/juntossomosmais/atomium/assets/31256653/fe8876a8-609c-4b15-adf9-d5edfa72b1f2)
![image](https://github.com/juntossomosmais/atomium/assets/31256653/06ddc81c-0439-4ef4-9aea-4ac9f80ab08b)

