### PR TITLE
feat: add font size prop into icon component

### DIFF
--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -94,6 +94,7 @@ export namespace Components {
     }
     interface AtomIcon {
         "color"?: Color;
+        "fontSize"?: string;
         "icon"?: IconProps;
         "size"?: 'small' | 'large';
     }
@@ -542,6 +543,7 @@ declare namespace LocalJSX {
     }
     interface AtomIcon {
         "color"?: Color;
+        "fontSize"?: string;
         "icon"?: IconProps;
         "size"?: 'small' | 'large';
     }

--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -94,9 +94,8 @@ export namespace Components {
     }
     interface AtomIcon {
         "color"?: Color;
-        "fontSize"?: string;
         "icon"?: IconProps;
-        "size"?: 'small' | 'large';
+        "size"?: Size;
     }
     interface AtomInput {
         "autocomplete"?: 'on' | 'off';
@@ -543,9 +542,8 @@ declare namespace LocalJSX {
     }
     interface AtomIcon {
         "color"?: Color;
-        "fontSize"?: string;
         "icon"?: IconProps;
-        "size"?: 'small' | 'large';
+        "size"?: Size;
     }
     interface AtomInput {
         "autocomplete"?: 'on' | 'off';

--- a/packages/core/src/components/icon/icon.spec.ts
+++ b/packages/core/src/components/icon/icon.spec.ts
@@ -1,28 +1,32 @@
-import { newSpecPage } from '@stencil/core/testing'
+import { SpecPage, newSpecPage } from '@stencil/core/testing'
 
 import { AtomIcon } from './icon'
 
 const URL_MOCK = 'https://atomium.juntossomosmais.com.br/icons'
 
 describe('atom-icon', () => {
-  it('should render ion-icon element', async () => {
-    const page = await newSpecPage({
+  let page: SpecPage
+
+  beforeEach(async () => {
+    page = await newSpecPage({
       components: [AtomIcon],
       html: `<atom-icon icon="heart" color="primary" size="large"></atom-icon>`,
     })
+  })
 
-    if (!page?.root?.shadowRoot) {
-      throw new Error('page.root is undefined')
-    }
+  it('should size attributte to be filed with size prop when its an enum type', () => {
+    expect(page?.root?.shadowRoot).toEqualHtml(`
+      <ion-icon color="primary" icon="${URL_MOCK}/heart.svg" size="large"></ion-icon>
+    `)
+  })
+
+  it('should style font-size to be filed with size prop when its an number type', async () => {
+    page?.root?.setAttribute('size', '10')
 
     await page.waitForChanges()
 
-    expect(page.root).toEqualHtml(`
-      <atom-icon aria-hidden="true" color="primary" icon="heart" size="large">
-        <mock:shadow-root>
-          <ion-icon color="primary" icon="${URL_MOCK}/heart.svg" size="large"></ion-icon>
-        </mock:shadow-root>
-      </atom-icon>
+    expect(page?.root?.shadowRoot).toEqualHtml(`
+      <ion-icon color="primary" icon="${URL_MOCK}/heart.svg" size="" style="font-size: 10px;"></ion-icon>
     `)
   })
 })

--- a/packages/core/src/components/icon/icon.tsx
+++ b/packages/core/src/components/icon/icon.tsx
@@ -13,6 +13,7 @@ const CDN_URL = 'https://atomium.juntossomosmais.com.br/icons'
 export class AtomIcon {
   @Prop() color?: Color
   @Prop() icon?: IconProps
+  @Prop() fontSize?: string
   @Prop() size?: 'small' | 'large'
 
   render(): JSX.Element {
@@ -22,6 +23,7 @@ export class AtomIcon {
           icon={`${CDN_URL}/${this.icon}.svg`}
           color={this.color}
           size={this.size}
+          style={{ fontSize: this.fontSize }}
         />
       </Host>
     )

--- a/packages/core/src/components/icon/icon.tsx
+++ b/packages/core/src/components/icon/icon.tsx
@@ -1,9 +1,11 @@
 import { Color } from '@ionic/core'
-import { Component, Host, Prop, h } from '@stencil/core'
+import { Component, Host, Prop, State, Watch, h } from '@stencil/core'
 
 import { IconProps } from '../../icons'
 
 const CDN_URL = 'https://atomium.juntossomosmais.com.br/icons'
+
+type Size = 'small' | 'large' | number
 
 @Component({
   tag: 'atom-icon',
@@ -13,8 +15,30 @@ const CDN_URL = 'https://atomium.juntossomosmais.com.br/icons'
 export class AtomIcon {
   @Prop() color?: Color
   @Prop() icon?: IconProps
-  @Prop() fontSize?: string
-  @Prop() size?: 'small' | 'large'
+  @Prop() size?: Size
+
+  @State() validateSize?: string = ''
+  @State() fontSize?: string = ''
+
+  private updateSize(newSize: Size) {
+    this.validateSize = ''
+    this.fontSize = ''
+
+    if (newSize === 'small' || newSize === 'large') {
+      this.validateSize = newSize
+    } else if (newSize > 0) {
+      this.fontSize = `${newSize}px`
+    }
+  }
+
+  @Watch('size')
+  watchPropHandler(newSize: Size) {
+    this.updateSize(newSize)
+  }
+
+  componentWillLoad() {
+    this.updateSize(this.size)
+  }
 
   render(): JSX.Element {
     return (
@@ -22,7 +46,7 @@ export class AtomIcon {
         <ion-icon
           icon={`${CDN_URL}/${this.icon}.svg`}
           color={this.color}
-          size={this.size}
+          size={this.validateSize}
           style={{ fontSize: this.fontSize }}
         />
       </Host>

--- a/packages/core/src/components/icon/stories/icon.args.ts
+++ b/packages/core/src/components/icon/stories/icon.args.ts
@@ -36,17 +36,9 @@ export const IconStoryArgs = {
       },
     },
     size: {
-      control: 'select',
-      description: 'The size of the icon.',
-      options: ['small', 'large'],
-      table: {
-        category: Category.PROPERTIES,
-      },
-    },
-    fontSize: {
       control: 'text',
       description:
-        'Alternative prop to customize the icon with a specific size. When size is set, this prop is ignored.',
+        'The size of the icon. Use large or small to change the size of the icon or pass a number to set the font-size in pixels.',
       table: {
         category: Category.PROPERTIES,
       },

--- a/packages/core/src/components/icon/stories/icon.args.ts
+++ b/packages/core/src/components/icon/stories/icon.args.ts
@@ -43,11 +43,19 @@ export const IconStoryArgs = {
         category: Category.PROPERTIES,
       },
     },
+    fontSize: {
+      control: 'text',
+      description:
+        'Alternative prop to customize the icon with a specific size. When size is set, this prop is ignored.',
+      table: {
+        category: Category.PROPERTIES,
+      },
+    },
   },
 }
 
 export const IconComponentArgs = {
   icon: 'heart',
   color: 'secondary',
-  size: 'large',
+  size: '',
 }

--- a/packages/core/src/components/icon/stories/icon.core.stories.tsx
+++ b/packages/core/src/components/icon/stories/icon.core.stories.tsx
@@ -1,5 +1,4 @@
 import { Meta, StoryObj } from '@storybook/web-components'
-
 import { html } from 'lit'
 
 import { IconComponentArgs, IconStoryArgs } from './icon.args'
@@ -11,7 +10,12 @@ export default {
 
 const createIcon = (args) => {
   return html`
-    <atom-icon icon=${args.icon} color=${args.color} size=${args.size} />
+    <atom-icon
+      icon=${args.icon}
+      color=${args.color}
+      font-size=${args.fontSize}
+      size=${args.size}
+    />
   `
 }
 

--- a/packages/core/src/components/icon/stories/icon.core.stories.tsx
+++ b/packages/core/src/components/icon/stories/icon.core.stories.tsx
@@ -10,12 +10,7 @@ export default {
 
 const createIcon = (args) => {
   return html`
-    <atom-icon
-      icon=${args.icon}
-      color=${args.color}
-      font-size=${args.fontSize}
-      size=${args.size}
-    />
+    <atom-icon icon=${args.icon} color=${args.color} size=${args.size} />
   `
 }
 


### PR DESCRIPTION
## Infos

[Task](https://juntossomosmais.monday.com/boards/5143488854/views/113762127/pulses/6008499016)

#### What is being delivered?

Change size prop into icon component to set font-size style value. This component use font-size css to do this customization as recommended by [ionic icon](https://ionic.io/ionicons/usage?_gl=1*1d4s5r6*_ga*OTIwNTQxNzI1LjE2OTcwNTAwMTU.*_ga_REH9TJF6KF*MTcwNzQ4MzMwNS43LjEuMTcwNzQ4MzM0MS4wLjAuMA..)

#### What impacts?

Alternative prop to customize icon size with specific values

#### Reversal plan

Describe which plan we should follow if this delivery has to be reversed.

#### Evidences

![image](https://github.com/juntossomosmais/atomium/assets/106702647/d517a177-aab6-4d27-b165-19ef033c215a)
