### PR TITLE
fix(alert): remove wrong width on icon size

### DIFF
--- a/packages/core/src/components/alert/alert.scss
+++ b/packages/core/src/components/alert/alert.scss
@@ -115,8 +115,7 @@
 
 .atom-icon {
   font-size: var(--icon-size);
-  /* @todo(icons): re-evaluate this when finalizing the icon package */
-  margin-top: 2px;
+  width: var(--space-large);
 }
 
 .atom-close {

--- a/packages/core/src/components/alert/alert.scss
+++ b/packages/core/src/components/alert/alert.scss
@@ -117,7 +117,6 @@
   font-size: var(--icon-size);
   /* @todo(icons): re-evaluate this when finalizing the icon package */
   margin-top: 2px;
-  width: var(--spacing-medium);
 }
 
 .atom-close {


### PR DESCRIPTION
## Infos

#### What is being delivered?

- Remove the wrong `width`
- Remove unnecessary `margin-top`

#### What impacts?

This width was flattening the icon wrongly

#### Evidences

Before
<img width="779" alt="image" src="https://github.com/juntossomosmais/atomium/assets/3603793/d214b290-31f1-416f-bf2d-b1265a427a23">

After
<img width="775" alt="image" src="https://github.com/juntossomosmais/atomium/assets/3603793/f1af6266-8c82-485d-b19f-009b6557c85c">

