### PR TITLE
fix(button): adjust button slot align

### DIFF
--- a/packages/core/src/components/button/button.scss
+++ b/packages/core/src/components/button/button.scss
@@ -15,6 +15,7 @@
 
 .atom-button {
   text-transform: inherit;
+
   &[color='white'] {
     --ion-color-base: var(--color-neutral-white);
     --ion-color-contrast: var(--color-neutral-black);
@@ -77,6 +78,7 @@
   }
 
   .slot {
+    align-items: center;
     display: flex;
     gap: var(--spacing-xsmall);
   }


### PR DESCRIPTION
## Infos

#### What is being delivered?

- Adjust button slot align to center

#### What impacts?

- Button component with an icon

#### Evidences

| Before | After |
| ----- | ------ | 
| ![before](https://github.com/juntossomosmais/atomium/assets/20569339/46211e96-9d5e-42d9-99b9-73eb2d025f6c) | ![after](https://github.com/juntossomosmais/atomium/assets/20569339/88258ac9-d260-4a53-a289-ee34fe03e123) |