### PR TITLE
feat(grid): add possibility to define padding

### DIFF
--- a/packages/core/src/components/grid/grid.scss
+++ b/packages/core/src/components/grid/grid.scss
@@ -1,7 +1,23 @@
 @import '~@atomium/scss-utils/index';
 
+:host {
+  --atom-grid-padding: 0;
+}
+
 .atom-grid {
   display: flex;
   flex-wrap: wrap;
   margin: calc(var(--grid-gap) / -2);
+  padding: var(--atom-grid-padding);
+
+  @each $scale-full-name, $scale-alias in $screens-alias {
+    @if $scale-alias != 'xs' {
+      @include above($scale-full-name) {
+        padding: var(
+          --atom-grid-padding-#{$scale-alias},
+          var(--atom-grid-padding)
+        );
+      }
+    }
+  }
 }

--- a/packages/core/src/components/grid/stories/grid.args.ts
+++ b/packages/core/src/components/grid/stories/grid.args.ts
@@ -1,7 +1,6 @@
 import { Category } from '@atomium/storybook-utils/enums/table'
 import { withActions } from '@storybook/addon-actions/decorator'
 
-
 export const GridStoryArgs = {
   decorators: [withActions],
   parameters: {
@@ -53,6 +52,56 @@ export const GridStoryArgs = {
       description:
         'Defines the space between the elements in a row of the Grid system. For screens below `medium` size, the gap value will be `var(--spacing-xsmall)`.',
       defaultValue: { summary: 'var(--spacing-base)' },
+      table: {
+        category: Category.CSS_CUSTOM_PROPERTIES,
+      },
+    },
+    '--atom-grid-padding': {
+      description:
+        'Define padding on the grid can be set for all breakpoints and default for xs screens.',
+      defaultValue: { summary: '0' },
+      table: {
+        category: Category.CSS_CUSTOM_PROPERTIES,
+      },
+    },
+    '--atom-grid-padding-sm': {
+      description: 'Define padding on small screens.',
+      table: {
+        category: Category.CSS_CUSTOM_PROPERTIES,
+      },
+    },
+    '--atom-grid-padding-md': {
+      description: 'Define padding on medium screens.',
+      table: {
+        category: Category.CSS_CUSTOM_PROPERTIES,
+      },
+    },
+    '--atom-grid-padding-lg': {
+      description: 'Define padding on large screens.',
+      table: {
+        category: Category.CSS_CUSTOM_PROPERTIES,
+      },
+    },
+    '--atom-grid-padding-xlg': {
+      description: 'Define padding on xlarge screens.',
+      table: {
+        category: Category.CSS_CUSTOM_PROPERTIES,
+      },
+    },
+    '--atom-grid-padding-fhd': {
+      description: 'Define padding on full hd screens.',
+      table: {
+        category: Category.CSS_CUSTOM_PROPERTIES,
+      },
+    },
+    '--atom-grid-padding-2k': {
+      description: 'Define padding on 2K screens.',
+      table: {
+        category: Category.CSS_CUSTOM_PROPERTIES,
+      },
+    },
+    '--atom-grid-padding-4k': {
+      description: 'Define padding on 4K screens.',
       table: {
         category: Category.CSS_CUSTOM_PROPERTIES,
       },

--- a/utils/scss/screens.scss
+++ b/utils/scss/screens.scss
@@ -9,6 +9,18 @@ $screen-fhd: 1920px; // Full HD resolution
 $screen-2k: 2048px; // 2K resolution
 $screen-4k: 3840px; // 4K resolution
 
+$screens-alias: (
+  'xsmall': 'xs',
+  'small': 'sm',
+  'medium': 'md',
+  'large': 'lg',
+  'xlarge': 'xlg',
+  'xxlarge': 'fhd',
+  'xxxlarge': 'xxxlarge',
+  'desktop2k': '2k',
+  'desktop4k': '4k',
+);
+
 $rupture: map-merge(
   $rupture,
   (


### PR DESCRIPTION
## Infos

[Task](https://juntossomosmais.monday.com/boards/1521247929/views/139997903/pulses/6364196601)

#### What is being delivered?

Added the ability to define padding for all breakpoints, documented in Storybook. The approach is mobile-first, using var(--atom-grid-padding) for breakpoints on x-small screens and when not define a specific padding in this X breakpoint.

#### What impacts?

- Atom-Grid

#### Reversal plan

Describe which plan we should follow if this delivery has to be reversed.

#### Evidences

Storybook

<img width="1008" alt="Captura de Tela 2024-05-25 às 07 10 49" src="https://github.com/juntossomosmais/atomium/assets/54173994/047c5ddf-961c-4f5b-93a7-10466ea81174">

Funcionality

https://github.com/juntossomosmais/atomium/assets/54173994/aab3465f-ae4c-4749-9194-01dd4d3e1fa8

