### PR TITLE
fix(vue): convert just atom prefixed events to kebab case on install

### DIFF
--- a/packages/vue/src/plugin.ts
+++ b/packages/vue/src/plugin.ts
@@ -12,12 +12,11 @@ export const ComponentLibrary: Plugin = {
   async install() {
     applyPolyfills().then(() => {
       defineCustomElements(window, {
-        ael: (el: any, eventName: string, cb: any, opts: any) =>
-          el.addEventListener(eventName.toLowerCase(), cb, opts),
-        rel: (el: any, eventName: string, cb: any, opts: any) =>
-          el.removeEventListener(eventName.toLowerCase(), cb, opts),
         ce: (eventName: string, opts: any) =>
-          new CustomEvent(toKebabCase(eventName), opts),
+          new CustomEvent(
+            eventName.startsWith('atom') ? toKebabCase(eventName) : eventName,
+            opts
+          ),
       } as any)
     })
   },


### PR DESCRIPTION
## Infos

[Task](https://juntossomosmais.monday.com/boards/3957397225/pulses/6836584226)

#### What is being delivered?

- remove `ael` and `rel` from logic to convert events to lowercase
- in `ce` add just `atom` prefixed events to kebab case on install

#### What impacts?

This change should not impact any current functionality as it is a bug fix to avoid bad behavior when using `atom` prefixed events together with `ion` prefixed events.

closes #467

#### Reversal plan

Revert the changes in the codebase
