### PR TITLE
fix(core): avoid to prev button hiding during loop

### DIFF
--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -7,10 +7,10 @@
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
 import { IconProps } from "./icons";
 import { Color, Mode, TextFieldTypes } from "@ionic/core";
-import { LocalJSX as IonTypes } from "@ionic/core/dist/types/components";
+import { IonTypes } from "@ionic/core/dist/types/components";
 export { IconProps } from "./icons";
 export { Color, Mode, TextFieldTypes } from "@ionic/core";
-export { LocalJSX as IonTypes } from "@ionic/core/dist/types/components";
+export { IonTypes } from "@ionic/core/dist/types/components";
 export namespace Components {
     interface AtomAlert {
         "actionText"?: string;

--- a/packages/core/src/components/carousel/carousel.tsx
+++ b/packages/core/src/components/carousel/carousel.tsx
@@ -152,7 +152,7 @@ export class AtomCarousel {
               class='carousel-navigation navigation--prev'
               role='button'
               aria-label='Previous'
-              aria-disabled='true'
+              aria-disabled={this.loop ? 'false' : 'true'}
               onClick={(event) => this.handleNavigationClick(event)}
             >
               <atom-icon icon='chevron-left'></atom-icon>


### PR DESCRIPTION
## Infos

#### What is being delivered?

- Add a rule to avoid `disabled="true"` during loop

#### What impacts?

During the loop, the previous button was hiding. This PR will resolve this issue. 
