### PR TITLE
feat(core): add dispatch event after transition end

### DIFF
--- a/packages/core/src/components/carousel/carousel.tsx
+++ b/packages/core/src/components/carousel/carousel.tsx
@@ -28,6 +28,12 @@ export class AtomCarousel {
 
     this.currentIdx = value
     this.carouselWrapper.style.transform = `translateX(-${this.currentIndex * 100}%)`
+
+    const transitionendEvent = new CustomEvent('transitionend', {
+      detail: { currentIndex: this.currentIndex },
+    })
+
+    window.dispatchEvent(transitionendEvent)
   }
 
   carouselWrapper: HTMLElement

--- a/packages/core/src/components/carousel/stories/carousel.args.ts
+++ b/packages/core/src/components/carousel/stories/carousel.args.ts
@@ -76,6 +76,13 @@ export const CarouselStoryArgs = {
         category: Category.CSS_CUSTOM_PROPERTIES,
       },
     },
+    'CustomEvent("transitionend")': {
+      description:
+        'The event dispatched when transition ends to use in the parent component, for example for add a class to the current slide or add a lazy load to the images.',
+      table: {
+        category: Category.EVENTS,
+      },
+    },
   },
 }
 

--- a/packages/core/src/components/list-slider/list-slider.tsx
+++ b/packages/core/src/components/list-slider/list-slider.tsx
@@ -60,6 +60,12 @@ export class AtomListSlider {
     if (!this.sliderItems) return
 
     this.updateSliderPosition()
+
+    const transitionendEvent = new CustomEvent('transitionend', {
+      detail: { currentIndex: this.currentIndex },
+    })
+
+    window.dispatchEvent(transitionendEvent)
   }
 
   componentDidLoad() {

--- a/packages/core/src/components/list-slider/stories/list-slider.args.ts
+++ b/packages/core/src/components/list-slider/stories/list-slider.args.ts
@@ -67,6 +67,13 @@ export const ListSliderStoryArgs = {
         category: Category.EVENTS,
       },
     },
+    'CustomEvent("transitionend")': {
+      description:
+        'The event dispatched when transition ends to use in the parent component, for example for add a class to the current slide or add a lazy load to the images.',
+      table: {
+        category: Category.EVENTS,
+      },
+    },
   },
 }
 


### PR DESCRIPTION
## Infos

#### What is being delivered?

- Add a dispatch event after the transition end of the carousel and list slider components.

#### What impacts?

This change will allow the user to know when the transition ends and can perform some action, for example adding a class to the element or using lazy loading together with `Intersection Observer`