### PR TITLE
feat(icons): add watch-later icon mdi

### DIFF
--- a/packages/core/src/icons.d.ts
+++ b/packages/core/src/icons.d.ts
@@ -173,5 +173,7 @@ export type IconProps =
   | 'upload-outline'
   | 'upload'
   | 'wallet-giftcard'
+  | 'watch-later-outline'
+  | 'watch-later'
   | 'whatsapp'
   | 'youtube'

--- a/packages/icons/svg/mdi/watch-later-outline.svg
+++ b/packages/icons/svg/mdi/watch-later-outline.svg
@@ -1,0 +1,11 @@
+<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+    <g clip-path="url(#clip0_1_6871)">
+        <path
+            d="M12 2C6.5 2 2 6.5 2 12C2 17.5 6.5 22 12 22C17.5 22 22 17.5 22 12C22 6.5 17.5 2 12 2ZM12 20C7.59 20 4 16.41 4 12C4 7.59 7.59 4 12 4C16.41 4 20 7.59 20 12C20 16.41 16.41 20 12 20ZM12.5 7H11V13L16.2 16.2L17 14.9L12.5 12.2V7Z" />
+    </g>
+    <defs>
+        <clipPath id="clip0_1_6871">
+            <rect width="24" height="24" />
+        </clipPath>
+    </defs>
+</svg>

--- a/packages/icons/svg/mdi/watch-later.svg
+++ b/packages/icons/svg/mdi/watch-later.svg
@@ -1,0 +1,11 @@
+<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+    <g clip-path="url(#clip0_1_3729)">
+        <path
+            d="M12 2C6.5 2 2 6.5 2 12C2 17.5 6.5 22 12 22C17.5 22 22 17.5 22 12C22 6.5 17.5 2 12 2ZM16.2 16.2L11 13V7H12.5V12.2L17 14.9L16.2 16.2Z" />
+    </g>
+    <defs>
+        <clipPath id="clip0_1_3729">
+            <rect width="24" height="24" />
+        </clipPath>
+    </defs>
+</svg>


### PR DESCRIPTION
## Infos

[Task](https://juntossomosmais.monday.com/boards/1521247929/views/139997903/pulses/7094878329)

#### What is being delivered?

Add watch-later icon
- Outline
- Filled

#### What impacts?

- Icons

#### Reversal plan

- Revert PR

#### Evidences

<img width="1105" alt="Captura de Tela 2024-07-25 às 11 26 15" src="https://github.com/user-attachments/assets/91b08081-5466-4485-b31f-3ebe0b001d35">
<img width="1096" alt="Captura de Tela 2024-07-25 às 11 26 24" src="https://github.com/user-attachments/assets/e87be5b0-97fa-4ceb-b645-5d0bf87d6e24">
