### PR TITLE
feat(component): create link component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31622,7 +31622,7 @@
     },
     "packages/core": {
       "name": "@juntossomosmais/atomium",
-      "version": "2.7.0"
+      "version": "2.9.0"
     },
     "packages/icons": {
       "name": "@juntossomosmais/atomium-icons"

--- a/packages/core/loader/cdn.js
+++ b/packages/core/loader/cdn.js
@@ -1,1 +1,3 @@
+
 module.exports = require('../dist/cjs/loader.cjs.js');
+module.exports.applyPolyfills = function() { return Promise.resolve() };

--- a/packages/core/loader/index.cjs.js
+++ b/packages/core/loader/index.cjs.js
@@ -1,1 +1,3 @@
+
 module.exports = require('../dist/cjs/loader.cjs.js');
+module.exports.applyPolyfills = function() { return Promise.resolve() };

--- a/packages/core/loader/index.d.ts
+++ b/packages/core/loader/index.d.ts
@@ -9,9 +9,6 @@ export interface CustomElementsDefineOptions {
   rel?: (el: EventTarget, eventName: string, listener: EventListenerOrEventListenerObject, options: boolean | AddEventListenerOptions) => void;
 }
 export declare function defineCustomElements(win?: Window, opts?: CustomElementsDefineOptions): void;
-/**
- * @deprecated
- */
 export declare function applyPolyfills(): Promise<void>;
 
 /**

--- a/packages/core/loader/index.es2017.js
+++ b/packages/core/loader/index.es2017.js
@@ -1,1 +1,3 @@
+
+export * from '../dist/esm/polyfills/index.js';
 export * from '../dist/esm/loader.js';

--- a/packages/core/loader/index.js
+++ b/packages/core/loader/index.js
@@ -1,2 +1,4 @@
+
 (function(){if("undefined"!==typeof window&&void 0!==window.Reflect&&void 0!==window.customElements){var a=HTMLElement;window.HTMLElement=function(){return Reflect.construct(a,[],this.constructor)};HTMLElement.prototype=a.prototype;HTMLElement.prototype.constructor=HTMLElement;Object.setPrototypeOf(HTMLElement,a)}})();
+export * from '../dist/esm/polyfills/index.js';
 export * from '../dist/esm/loader.js';

--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -143,6 +143,10 @@ export namespace Components {
         "type": TextFieldTypes;
         "value"?: IonTypes.IonInput['value'];
     }
+    interface AtomLink {
+        "color": 'primary' | 'secondary';
+        "type": 'anchor' | 'button';
+    }
     interface AtomListSlider {
         "centralized": boolean;
         "hasNavigation": boolean;
@@ -246,6 +250,10 @@ export interface AtomChipCustomEvent<T> extends CustomEvent<T> {
 export interface AtomInputCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLAtomInputElement;
+}
+export interface AtomLinkCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLAtomLinkElement;
 }
 export interface AtomListSliderCustomEvent<T> extends CustomEvent<T> {
     detail: T;
@@ -380,6 +388,23 @@ declare global {
         prototype: HTMLAtomInputElement;
         new (): HTMLAtomInputElement;
     };
+    interface HTMLAtomLinkElementEventMap {
+        "click": any;
+    }
+    interface HTMLAtomLinkElement extends Components.AtomLink, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLAtomLinkElementEventMap>(type: K, listener: (this: HTMLAtomLinkElement, ev: AtomLinkCustomEvent<HTMLAtomLinkElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLAtomLinkElementEventMap>(type: K, listener: (this: HTMLAtomLinkElement, ev: AtomLinkCustomEvent<HTMLAtomLinkElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+    }
+    var HTMLAtomLinkElement: {
+        prototype: HTMLAtomLinkElement;
+        new (): HTMLAtomLinkElement;
+    };
     interface HTMLAtomListSliderElementEventMap {
         "clickNext": any;
         "clickPrev": any;
@@ -464,6 +489,7 @@ declare global {
         "atom-grid": HTMLAtomGridElement;
         "atom-icon": HTMLAtomIconElement;
         "atom-input": HTMLAtomInputElement;
+        "atom-link": HTMLAtomLinkElement;
         "atom-list-slider": HTMLAtomListSliderElement;
         "atom-list-slider-item": HTMLAtomListSliderItemElement;
         "atom-select": HTMLAtomSelectElement;
@@ -608,6 +634,11 @@ declare namespace LocalJSX {
         "type"?: TextFieldTypes;
         "value"?: IonTypes.IonInput['value'];
     }
+    interface AtomLink {
+        "color"?: 'primary' | 'secondary';
+        "onClick"?: (event: AtomLinkCustomEvent<any>) => void;
+        "type"?: 'anchor' | 'button';
+    }
     interface AtomListSlider {
         "centralized"?: boolean;
         "hasNavigation"?: boolean;
@@ -716,6 +747,7 @@ declare namespace LocalJSX {
         "atom-grid": AtomGrid;
         "atom-icon": AtomIcon;
         "atom-input": AtomInput;
+        "atom-link": AtomLink;
         "atom-list-slider": AtomListSlider;
         "atom-list-slider-item": AtomListSliderItem;
         "atom-select": AtomSelect;
@@ -739,6 +771,7 @@ declare module "@stencil/core" {
             "atom-grid": LocalJSX.AtomGrid & JSXBase.HTMLAttributes<HTMLAtomGridElement>;
             "atom-icon": LocalJSX.AtomIcon & JSXBase.HTMLAttributes<HTMLAtomIconElement>;
             "atom-input": LocalJSX.AtomInput & JSXBase.HTMLAttributes<HTMLAtomInputElement>;
+            "atom-link": LocalJSX.AtomLink & JSXBase.HTMLAttributes<HTMLAtomLinkElement>;
             "atom-list-slider": LocalJSX.AtomListSlider & JSXBase.HTMLAttributes<HTMLAtomListSliderElement>;
             "atom-list-slider-item": LocalJSX.AtomListSliderItem & JSXBase.HTMLAttributes<HTMLAtomListSliderItemElement>;
             "atom-select": LocalJSX.AtomSelect & JSXBase.HTMLAttributes<HTMLAtomSelectElement>;

--- a/packages/core/src/components/link/link.scss
+++ b/packages/core/src/components/link/link.scss
@@ -1,0 +1,28 @@
+@import '~@atomium/scss-utils/index';
+
+:host {
+  display: inline-block;
+}
+
+.atom-link {
+  cursor: pointer;
+  font: var(--text-link-medium);
+  letter-spacing: var(--text-link-medium-letter);
+  text-decoration: underline;
+
+
+  &[color='primary'] {
+    color: var(--color-brand-primary-regular);
+  }
+
+  &[color='secondary'] {
+    color: var(--color-brand-secondary-regular)
+  }
+
+  &__button {
+    background: none;
+    border: none;
+    padding: 0;
+    text-decoration: none;
+  }
+}

--- a/packages/core/src/components/link/link.scss
+++ b/packages/core/src/components/link/link.scss
@@ -25,6 +25,7 @@
     background: none;
     border: none;
     padding: 0;
+    position: relative;
     text-decoration: none;
   }
 }

--- a/packages/core/src/components/link/link.scss
+++ b/packages/core/src/components/link/link.scss
@@ -5,11 +5,13 @@
 }
 
 .atom-link {
+  align-items: center;
   cursor: pointer;
+  display: flex;
   font: var(--text-link-medium);
+  gap: var(--spacing-xxsmall);
   letter-spacing: var(--text-link-medium-letter);
   text-decoration: underline;
-
 
   &[color='primary'] {
     color: var(--color-brand-primary-regular);

--- a/packages/core/src/components/link/link.spec.ts
+++ b/packages/core/src/components/link/link.spec.ts
@@ -1,0 +1,74 @@
+import { newSpecPage } from '@stencil/core/testing'
+
+import { AtomLink } from './link'
+
+describe('atom-link', () => {
+  it('should render a span element with secondary color - default mode', async () => {
+    const page = await newSpecPage({
+      components: [AtomLink],
+      html: `<atom-link>styled link</atom-link>`,
+    })
+
+    await page.waitForChanges()
+
+    expect(page.root).toEqualHtml(`
+      <atom-link>
+        <mock:shadow-root>
+        <span class="atom-link" color="primary">
+           <slot></slot>
+         </span>
+        </mock:shadow-root>
+        styled link
+      </atom-link>
+    `)
+  })
+
+  it('should render a span element with secondary color', async () => {
+    const page = await newSpecPage({
+      components: [AtomLink],
+      html: `<atom-link color="secondary">styled link</atom-link>`,
+    })
+
+    await page.waitForChanges()
+
+    expect(page.root).toEqualHtml(`
+      <atom-link color="secondary">
+        <mock:shadow-root>
+        <span class="atom-link" color="secondary">
+           <slot></slot>
+         </span>
+        </mock:shadow-root>
+        styled link
+      </atom-link>
+    `)
+  })
+
+  it('should render a clickable button element with secondary color ', async () => {
+    const page = await newSpecPage({
+      components: [AtomLink],
+      html: `<atom-link color="secondary" type="button">styled link</atom-link>`,
+    })
+
+    await page.waitForChanges()
+
+    expect(page.root).toEqualHtml(`
+      <atom-link color="secondary" type="button">
+        <mock:shadow-root>
+        <button class="atom-link__button">
+          <span class="atom-link" color="secondary">
+            <slot></slot>
+          </span>
+         </button>
+        </mock:shadow-root>
+        styled link
+      </atom-link>
+    `)
+
+    const buttonEl = page.root?.shadowRoot?.querySelector('button')
+    const clickEventSpy = jest.spyOn(page.rootInstance.click, 'emit')
+
+    buttonEl?.click()
+
+    expect(clickEventSpy).toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/components/link/link.tsx
+++ b/packages/core/src/components/link/link.tsx
@@ -1,0 +1,41 @@
+import { Component, Event, EventEmitter, Host, Prop, h } from '@stencil/core'
+
+@Component({
+  tag: 'atom-link',
+  styleUrl: 'link.scss',
+  shadow: true,
+})
+export class AtomLink {
+  @Prop() color: 'primary' | 'secondary' = 'primary'
+  @Prop() type: 'anchor' | 'button' = 'anchor'
+
+  @Event() click: EventEmitter
+
+  private handleClick = (event: MouseEvent) => {
+    event.preventDefault()
+    event.stopPropagation()
+
+    return this.click.emit(event)
+  }
+
+  render() {
+    return (
+      <Host>
+        {this.type === 'anchor' ? (
+          <span class='atom-link' color={this.color}>
+            <slot />
+          </span>
+        ) : (
+          <button
+            class='atom-link__button'
+            onClick={this.handleClick.bind(this)}
+          >
+            <span class='atom-link' color={this.color}>
+              <slot />
+            </span>
+          </button>
+        )}
+      </Host>
+    )
+  }
+}

--- a/packages/core/src/components/link/stories/link.args.ts
+++ b/packages/core/src/components/link/stories/link.args.ts
@@ -1,0 +1,29 @@
+export const LinkStoryArgs = {
+  decorators: [],
+  parameters: {
+    actions: {
+      handles: [],
+    },
+    docs: {
+      description: {
+        component:
+          'Link components are link children styled components. They are used to navigate to different pages (when used inside router components, such as router-link(Vue) and Link(Next)) or used to trigger user actions.',
+      },
+    },
+  },
+  argTypes: {
+    color: {
+      control: 'select',
+      options: ['primary', 'secondary'],
+      defaultValue: { summary: 'primary' },
+      description: 'The link color.',
+    },
+    type: {
+      control: 'select',
+      options: ['anchor', 'button'],
+      defaultValue: { summary: 'anchor' },
+      description:
+        'The link type. Use anchor for navigation (combined with router-link or Link) and button for user actions.',
+    },
+  },
+}

--- a/packages/core/src/components/link/stories/link.args.ts
+++ b/packages/core/src/components/link/stories/link.args.ts
@@ -7,7 +7,7 @@ export const LinkStoryArgs = {
     docs: {
       description: {
         component:
-          'Link components are link children styled components. They are used to navigate to different pages (when used inside router components, such as router-link(Vue) and Link(Next)) or used to trigger user actions.',
+          'atom-link components are link children styled components. They are used to navigate to different pages (when used inside router components, such as router-link(Vue) and Link(Next)) or used to trigger user actions.',
       },
     },
   },
@@ -23,7 +23,25 @@ export const LinkStoryArgs = {
       options: ['anchor', 'button'],
       defaultValue: { summary: 'anchor' },
       description:
-        'The link type. Use anchor for navigation (combined with router-link or Link) and button for user actions.',
+        'The atom-link type. Use anchor for navigation (combined with router-link or Link) and button for user actions.',
     },
   },
 }
+
+const LinkReactStoryArgs = JSON.parse(JSON.stringify(LinkStoryArgs))
+
+LinkReactStoryArgs.parameters.docs.description.component =
+  'atom-link components are link children styled components. They are used to navigate to different pages (when used inside Link(Next)) or used to trigger user actions.<br/><br/> OBS: Link (Next) component does not render a anchor tag by default, so you need to wrap it with a tag for semantic reasons. You can create a wrapper component on your project to do this.'
+
+LinkReactStoryArgs.argTypes.type.description =
+  'The atom-link type. Use anchor for navigation (combined with Link) and button for user actions.'
+
+const LinkVueStoryArgs = JSON.parse(JSON.stringify(LinkStoryArgs))
+
+LinkVueStoryArgs.parameters.docs.description.component =
+  'atom-link components are link children styled components. They are used to navigate to different pages (when used inside router-link or NuxtLink or used to trigger user actions.'
+
+LinkVueStoryArgs.argTypes.type.description =
+  'The atom-link type. Use anchor for navigation (combined with router-link or NuxtLink) and button for user actions.'
+
+export { LinkReactStoryArgs, LinkVueStoryArgs }

--- a/packages/core/src/components/link/stories/link.core.stories.tsx
+++ b/packages/core/src/components/link/stories/link.core.stories.tsx
@@ -13,9 +13,11 @@ const createLink = (
   textExample = 'It should be used inside router components'
 ) => {
   return html`
-    <atom-link type="${args.type}" color="${args.color}">
-      ${textExample}
-    </atom-link>
+    <a href="/nice-example">
+      <atom-link type="${args.type}" color="${args.color}">
+        ${textExample}
+      </atom-link>
+    </a>
   `
 }
 
@@ -36,8 +38,11 @@ export const Secondary: StoryObj = {
 }
 
 export const Button: StoryObj = {
-  render: (args) =>
-    createLink(args, 'It should be used to trigger user actions'),
+  render: (args) => html`
+    <atom-link type="${args.type}" color="${args.color}">
+      It is a button! and can be used to trigger user actions
+    </atom-link>
+  `,
   args: {
     ...Primary.args,
     type: 'button',

--- a/packages/core/src/components/link/stories/link.core.stories.tsx
+++ b/packages/core/src/components/link/stories/link.core.stories.tsx
@@ -1,0 +1,43 @@
+import { Meta, StoryObj } from '@storybook/web-components'
+import { html } from 'lit'
+
+import { LinkStoryArgs } from './link.args'
+
+export default {
+  title: 'Components/Link',
+  ...LinkStoryArgs,
+} as Meta
+
+const createLink = (args) => {
+  return html`
+    <atom-link type="${args.type}" color="${args.color}">
+      ${args.textExample}
+    </atom-link>
+  `
+}
+
+export const Primary: StoryObj = {
+  render: (args) => createLink(args),
+  args: {
+    type: 'anchor',
+    color: 'primary',
+    textExample: 'It should be used inside router components',
+  },
+}
+
+export const Secondary: StoryObj = {
+  render: (args) => createLink(args),
+  args: {
+    ...Primary.args,
+    color: 'secondary',
+  },
+}
+
+export const Button: StoryObj = {
+  render: (args) => createLink(args),
+  args: {
+    ...Primary.args,
+    type: 'button',
+    textExample: 'It should be used to trigger user actions',
+  },
+}

--- a/packages/core/src/components/link/stories/link.core.stories.tsx
+++ b/packages/core/src/components/link/stories/link.core.stories.tsx
@@ -37,6 +37,21 @@ export const Secondary: StoryObj = {
   },
 }
 
+export const WithIcon: StoryObj = {
+  render: (args) => html`
+    <a href="/nice-example">
+      <atom-link type="${args.type}" color="${args.color}">
+        <span> Nice example with icon </span>
+        <atom-icon icon="heart" />
+      </atom-link>
+    </a>
+  `,
+  args: {
+    ...Primary.args,
+    color: 'secondary',
+  },
+}
+
 export const Button: StoryObj = {
   render: (args) => html`
     <atom-link type="${args.type}" color="${args.color}">

--- a/packages/core/src/components/link/stories/link.react.stories.tsx
+++ b/packages/core/src/components/link/stories/link.react.stories.tsx
@@ -1,4 +1,4 @@
-import { AtomLink } from '@juntossomosmais/atomium/react'
+import { AtomIcon, AtomLink } from '@juntossomosmais/atomium/react'
 import { Meta, StoryObj } from '@storybook/react'
 
 import { LinkReactStoryArgs } from './link.args'
@@ -39,6 +39,22 @@ export const Secondary: StoryObj = {
   args: {
     ...Primary.args,
     color: 'secondary',
+  },
+}
+
+export const WithIcon: StoryObj = {
+  render: (args) => (
+    <Link>
+      <a>
+        <AtomLink color={args.color} type={args.type}>
+          <span>Nice example with icon</span>
+          <AtomIcon icon='heart' color='primary' />
+        </AtomLink>
+      </a>
+    </Link>
+  ),
+  args: {
+    ...Primary.args,
   },
 }
 

--- a/packages/core/src/components/link/stories/link.react.stories.tsx
+++ b/packages/core/src/components/link/stories/link.react.stories.tsx
@@ -47,7 +47,7 @@ export const WithIcon: StoryObj = {
     <Link>
       <a>
         <AtomLink color={args.color} type={args.type}>
-          <span>Nice example with icon</span>
+          Nice example with icon
           <AtomIcon icon='heart' color='primary' />
         </AtomLink>
       </a>

--- a/packages/core/src/components/link/stories/link.react.stories.tsx
+++ b/packages/core/src/components/link/stories/link.react.stories.tsx
@@ -1,23 +1,22 @@
-import { Meta, StoryObj } from '@storybook/web-components'
-import { html } from 'lit'
+import { AtomLink } from '@juntossomosmais/atomium/react'
+import { Meta, StoryObj } from '@storybook/react'
 
 import { LinkStoryArgs } from './link.args'
 
 export default {
   title: 'Components/Link',
+  component: AtomLink,
   ...LinkStoryArgs,
 } as Meta
 
 const createLink = (
   args,
   textExample = 'It should be used inside router components'
-) => {
-  return html`
-    <atom-link type="${args.type}" color="${args.color}">
-      ${textExample}
-    </atom-link>
-  `
-}
+) => (
+  <AtomLink color={args.color} type={args.type}>
+    {textExample}
+  </AtomLink>
+)
 
 export const Primary: StoryObj = {
   render: (args) => createLink(args),

--- a/packages/core/src/components/link/stories/link.react.stories.tsx
+++ b/packages/core/src/components/link/stories/link.react.stories.tsx
@@ -1,21 +1,29 @@
 import { AtomLink } from '@juntossomosmais/atomium/react'
 import { Meta, StoryObj } from '@storybook/react'
 
-import { LinkStoryArgs } from './link.args'
+import { LinkReactStoryArgs } from './link.args'
+
+const Link = ({ children }) => {
+  return <>{children}</>
+}
 
 export default {
   title: 'Components/Link',
   component: AtomLink,
-  ...LinkStoryArgs,
+  ...LinkReactStoryArgs,
 } as Meta
 
 const createLink = (
   args,
-  textExample = 'It should be used inside router components'
+  textExample = 'It should be used inside Link (Next) component'
 ) => (
-  <AtomLink color={args.color} type={args.type}>
-    {textExample}
-  </AtomLink>
+  <Link>
+    <a>
+      <AtomLink color={args.color} type={args.type}>
+        {textExample}
+      </AtomLink>
+    </a>
+  </Link>
 )
 
 export const Primary: StoryObj = {
@@ -35,8 +43,11 @@ export const Secondary: StoryObj = {
 }
 
 export const Button: StoryObj = {
-  render: (args) =>
-    createLink(args, 'It should be used to trigger user actions'),
+  render: (args) => (
+    <AtomLink color={args.color} type={args.type}>
+      It is a button! and can be used to trigger user actions
+    </AtomLink>
+  ),
   args: {
     ...Primary.args,
     type: 'button',

--- a/packages/core/src/components/link/stories/link.vue.stories.tsx
+++ b/packages/core/src/components/link/stories/link.vue.stories.tsx
@@ -1,27 +1,43 @@
 import { AtomLink } from '@juntossomosmais/atomium/vue'
 import { Meta, StoryObj } from '@storybook/vue3'
+import { defineComponent, h } from 'vue'
 
-import { LinkStoryArgs } from './link.args'
+import { LinkVueStoryArgs } from './link.args'
+
+const RouterLink = defineComponent({
+  name: 'RouterLink',
+  props: {
+    to: {
+      type: String,
+      required: false,
+    },
+  },
+  setup(props, { slots }) {
+    return () => h('div', slots.default())
+  },
+})
 
 const createLink = (
   args,
   textExample = 'It should be used inside router components'
 ) => ({
-  components: { AtomLink },
+  components: { AtomLink, RouterLink },
   setup() {
     return { args }
   },
   template: `
-    <AtomLink color=${args.color} type=${args.type}>
-    ${textExample}
-  </AtomLink>
+  <router-link to="/nice-example">
+    <AtomLink :color="args.color" :type="args.type">
+      ${textExample}
+    </AtomLink>
+  </router-link>
   `,
 })
 
 export default {
   title: 'Components/Link',
   component: AtomLink,
-  ...LinkStoryArgs,
+  ...LinkVueStoryArgs,
 } as Meta
 
 export const Primary: StoryObj = {
@@ -41,8 +57,17 @@ export const Secondary: StoryObj = {
 }
 
 export const Button: StoryObj = {
-  render: (args) =>
-    createLink(args, 'It should be used to trigger user actions'),
+  render: (args) => ({
+    components: { AtomLink },
+    setup() {
+      return { args }
+    },
+    template: `
+          <AtomLink color=${args.color} type=${args.type}>
+          It is a button! and can be used to trigger user actions
+        </AtomLink>
+        `,
+  }),
   args: {
     ...Primary.args,
     type: 'button',

--- a/packages/core/src/components/link/stories/link.vue.stories.tsx
+++ b/packages/core/src/components/link/stories/link.vue.stories.tsx
@@ -65,13 +65,11 @@ export const WithIcon: StoryObj = {
     template: `
     <router-link to="/nice-example">
       <AtomLink :color="args.color" :type="args.type">
-        <span>
-          Nice example with icon
-        </span>
-        <AtomIcon
-          icon="heart"
-          color="primary"
-        />
+      Nice example with icon
+      <AtomIcon
+        icon="heart"
+        color="primary"
+      />
       </AtomLink>
     </router-link>
   `,

--- a/packages/core/src/components/link/stories/link.vue.stories.tsx
+++ b/packages/core/src/components/link/stories/link.vue.stories.tsx
@@ -1,23 +1,28 @@
-import { Meta, StoryObj } from '@storybook/web-components'
-import { html } from 'lit'
+import { AtomLink } from '@juntossomosmais/atomium/vue'
+import { Meta, StoryObj } from '@storybook/vue3'
 
 import { LinkStoryArgs } from './link.args'
-
-export default {
-  title: 'Components/Link',
-  ...LinkStoryArgs,
-} as Meta
 
 const createLink = (
   args,
   textExample = 'It should be used inside router components'
-) => {
-  return html`
-    <atom-link type="${args.type}" color="${args.color}">
-      ${textExample}
-    </atom-link>
-  `
-}
+) => ({
+  components: { AtomLink },
+  setup() {
+    return { args }
+  },
+  template: `
+    <AtomLink color=${args.color} type=${args.type}>
+    ${textExample}
+  </AtomLink>
+  `,
+})
+
+export default {
+  title: 'Components/Link',
+  component: AtomLink,
+  ...LinkStoryArgs,
+} as Meta
 
 export const Primary: StoryObj = {
   render: (args) => createLink(args),

--- a/packages/core/src/components/link/stories/link.vue.stories.tsx
+++ b/packages/core/src/components/link/stories/link.vue.stories.tsx
@@ -1,4 +1,4 @@
-import { AtomLink } from '@juntossomosmais/atomium/vue'
+import { AtomIcon, AtomLink } from '@juntossomosmais/atomium/vue'
 import { Meta, StoryObj } from '@storybook/vue3'
 import { defineComponent, h } from 'vue'
 
@@ -53,6 +53,31 @@ export const Secondary: StoryObj = {
   args: {
     ...Primary.args,
     color: 'secondary',
+  },
+}
+
+export const WithIcon: StoryObj = {
+  render: (args) => ({
+    components: { AtomLink, AtomIcon },
+    setup() {
+      return { args }
+    },
+    template: `
+    <router-link to="/nice-example">
+      <AtomLink :color="args.color" :type="args.type">
+        <span>
+          Nice example with icon
+        </span>
+        <AtomIcon
+          icon="heart"
+          color="primary"
+        />
+      </AtomLink>
+    </router-link>
+  `,
+  }),
+  args: {
+    ...Primary.args,
   },
 }
 


### PR DESCRIPTION
## Infos

Creating an atom-link component to be used combined with router components (such as Link, router-link and NuxtLink). Ideally, atom-link takes care of styling as router components work differently. This means we keep needing to import them when creating new anchor links. 

[Task](https://juntossomosmais.monday.com/boards/1757192123/views/36458908/pulses/7117677943)

#### What is being delivered?

Link component and its stories

#### What impacts?

Link components can be used on the projects. Available to test utilizing the version [2.10.0-alpha.2](https://github.com/juntossomosmais/atomium/pkgs/npm/atomium/250778260)

#### Reversal plan

Describe which plan we should follow if this delivery has to be reversed.

#### Evidences

##### React

- Link

[link-Link.webm](https://github.com/user-attachments/assets/1851393f-40fa-48b2-bbed-1b2021d4271f)

- button

[link-btn.webm](https://github.com/user-attachments/assets/8c94d549-4467-46a2-9b18-b0341ae251d3)

##### Vue

- NuxtLink

[link-nuxtlink.webm](https://github.com/user-attachments/assets/24855626-9df6-4f49-af73-416f729b1cf8)

- button

[link-button.webm](https://github.com/user-attachments/assets/785cf4e6-2759-40ba-aa3c-98b6dc607a9a)
