### PR TITLE
feat(carousel): reset autoplay when click on navigation and stop during mouse enter

### DIFF
--- a/packages/core/src/components/carousel/carousel.spec.ts
+++ b/packages/core/src/components/carousel/carousel.spec.ts
@@ -213,4 +213,68 @@ describe('AtomCarousel', () => {
     expect(page?.rootInstance.hasNavigation).toBe(false)
     expect(page?.rootInstance.hasPagination).toBe(false)
   })
+
+  it('should autoplay the carousel', async () => {
+    const page = await newSpecPage({
+      components: [AtomCarousel],
+      html: `
+        <atom-carousel autoplay="1000">
+          <atom-carousel-item>Slide 1</atom-carousel-item>
+          <atom-carousel-item>Slide 2</atom-carousel-item>
+        </atom-carousel>
+      `,
+    })
+
+    await page.waitForChanges()
+
+    expect(page?.rootInstance.autoplayIntervalId).toBeDefined()
+  })
+
+  it('should remove autoplay when mouse enter and restart when mouse leave', async () => {
+    const page = await newSpecPage({
+      components: [AtomCarousel],
+      html: `
+        <atom-carousel autoplay="1000">
+          <atom-carousel-item>Slide 1</atom-carousel-item>
+          <atom-carousel-item>Slide 2</atom-carousel-item>
+        </atom-carousel>
+      `,
+    })
+
+    await page.waitForChanges()
+
+    const carouselWrapper = page.root?.shadowRoot?.querySelector(
+      '.carousel-wrapper'
+    ) as HTMLElement
+
+    carouselWrapper?.dispatchEvent(new MouseEvent('mouseenter'))
+
+    expect(page?.rootInstance.autoplayIntervalId).toBeNull()
+
+    carouselWrapper?.dispatchEvent(new MouseEvent('mouseleave'))
+
+    expect(page?.rootInstance.autoplayIntervalId).toBeDefined()
+  })
+
+  it('should restart autoplay when click in navigation button', async () => {
+    const page = await newSpecPage({
+      components: [AtomCarousel],
+      html: `
+        <atom-carousel autoplay="1000">
+          <atom-carousel-item>Slide 1</atom-carousel-item>
+          <atom-carousel-item>Slide 2</atom-carousel-item>
+        </atom-carousel>
+      `,
+    })
+
+    await page.waitForChanges()
+
+    const nextButton = page.root?.shadowRoot?.querySelector(
+      '.navigation--next'
+    ) as HTMLElement
+
+    nextButton?.click()
+
+    expect(page?.rootInstance.autoplayIntervalId).toBeDefined()
+  })
 })

--- a/packages/core/src/components/carousel/carousel.tsx
+++ b/packages/core/src/components/carousel/carousel.tsx
@@ -61,6 +61,11 @@ export class AtomCarousel {
     this.carouselWrapper.addEventListener('touchstart', this.handleTouchStart)
     this.carouselWrapper.addEventListener('touchend', this.handleTouchEnd)
 
+    if (this.autoplay) {
+      this.carouselWrapper.addEventListener('mouseenter', this.stopAutoplay)
+      this.carouselWrapper.addEventListener('mouseleave', this.restartAutoplay)
+    }
+
     this.showOrHideNavigationButtons()
 
     if (this.autoplay > 0) this.startAutoplay()
@@ -72,6 +77,14 @@ export class AtomCarousel {
       this.handleTouchStart
     )
     this.carouselWrapper.removeEventListener('touchend', this.handleTouchEnd)
+
+    if (this.autoplay) {
+      this.carouselWrapper.removeEventListener('mouseenter', this.stopAutoplay)
+      this.carouselWrapper.removeEventListener(
+        'mouseleave',
+        this.restartAutoplay
+      )
+    }
   }
 
   componentWillUnmount() {
@@ -120,6 +133,19 @@ export class AtomCarousel {
       'aria-disabled',
       String(this.currentIndex === 0)
     )
+  }
+
+  stopAutoplay = () => {
+    if (this.autoplayIntervalId) {
+      clearInterval(this.autoplayIntervalId)
+      this.autoplayIntervalId = null
+    }
+  }
+
+  restartAutoplay = () => {
+    if (!this.autoplayIntervalId) {
+      this.startAutoplay()
+    }
   }
 
   startAutoplay() {

--- a/packages/core/src/components/carousel/carousel.tsx
+++ b/packages/core/src/components/carousel/carousel.tsx
@@ -101,6 +101,8 @@ export class AtomCarousel {
         (newIndex + this.carouselItems.length) % this.carouselItems.length
     }
 
+    if (this.autoplay > 0) this.startAutoplay()
+
     this.currentIndex = newIndex
     this.showOrHideNavigationButtons()
   }
@@ -121,6 +123,10 @@ export class AtomCarousel {
   }
 
   startAutoplay() {
+    if (this.autoplayIntervalId) {
+      clearInterval(this.autoplayIntervalId)
+    }
+
     this.loop = true
 
     this.autoplayIntervalId = setInterval(() => {


### PR DESCRIPTION
## Infos

#### What is being delivered?

- Restart the carousel autoplay count after clicking on the navigation
- Stop autoplay during mouse enter

#### What impacts?

This add some improvements about autoplay inside `atom-carousel`
