### PR TITLE
fix(alert): improve position of icon on single line

### DIFF
--- a/packages/core/src/components/alert/alert.scss
+++ b/packages/core/src/components/alert/alert.scss
@@ -1,5 +1,7 @@
 @import '~@atomium/scss-utils/index';
 
+$min-height-title: var(--spacing-large);
+
 :host {
   --close-size: var(--spacing-xxxlarge);
   --icon-size: var(--spacing-medium);
@@ -75,6 +77,7 @@
 .atom-title {
   font-weight: var(--font-weight-bold);
   margin: 0;
+  min-height: $min-height-title;
 
   &:not(:last-child) {
     margin-bottom: var(--spacing-xsmall);
@@ -118,8 +121,10 @@
 }
 
 .atom-icon {
+  align-items: center;
+  display: flex;
   font-size: var(--icon-size);
-  width: var(--space-large);
+  height: $min-height-title;
 }
 
 .atom-close {


### PR DESCRIPTION
#### What is being delivered?

- [improve the position of the icon on single line](https://github.com/juntossomosmais/atomium/commit/1110c7287f64dbc73d772cfb961b89ef3a1022bc)

#### What impacts?

Improve layout of the alert with an icon

#### Evidences

One line
<img width="696" alt="image" src="https://github.com/user-attachments/assets/a5613606-5363-4484-9f46-c69d9208820d">

Multiple line
<img width="701" alt="image" src="https://github.com/user-attachments/assets/8d5242ec-bf43-4541-bbe0-cf393a761f92">

