### PR TITLE
feat(select): define max-height and add variable to control it

### DIFF
--- a/packages/core/src/components/select/stories/select.args.ts
+++ b/packages/core/src/components/select/stories/select.args.ts
@@ -147,6 +147,13 @@ export const SelectStoryArgs = {
         category: Category.EVENTS,
       },
     },
+    '--select-max-height': {
+      description: 'Add a custom max-height to the select list options.',
+      defaultValue: { summary: '250px' },
+      table: {
+        category: Category.CSS_CUSTOM_PROPERTIES,
+      },
+    },
   },
 }
 

--- a/packages/core/src/components/select/stories/select.core.stories.tsx
+++ b/packages/core/src/components/select/stories/select.core.stories.tsx
@@ -15,46 +15,6 @@ const optionsDefault = [
     value: 'Green',
     disabled: false,
   },
-  {
-    id: '2',
-    value: 'Green',
-    disabled: false,
-  },
-  {
-    id: '2',
-    value: 'Green',
-    disabled: false,
-  },
-  {
-    id: '2',
-    value: 'Green',
-    disabled: false,
-  },
-  {
-    id: '2',
-    value: 'Green',
-    disabled: false,
-  },
-  {
-    id: '2',
-    value: 'Green',
-    disabled: false,
-  },
-  {
-    id: '2',
-    value: 'Green',
-    disabled: false,
-  },
-  {
-    id: '2',
-    value: 'Green',
-    disabled: false,
-  },
-  {
-    id: '2',
-    value: 'Green',
-    disabled: false,
-  },
   { id: '3', value: 'Blue', disabled: false },
   {
     id: '4',

--- a/packages/core/src/components/select/stories/select.core.stories.tsx
+++ b/packages/core/src/components/select/stories/select.core.stories.tsx
@@ -15,6 +15,46 @@ const optionsDefault = [
     value: 'Green',
     disabled: false,
   },
+  {
+    id: '2',
+    value: 'Green',
+    disabled: false,
+  },
+  {
+    id: '2',
+    value: 'Green',
+    disabled: false,
+  },
+  {
+    id: '2',
+    value: 'Green',
+    disabled: false,
+  },
+  {
+    id: '2',
+    value: 'Green',
+    disabled: false,
+  },
+  {
+    id: '2',
+    value: 'Green',
+    disabled: false,
+  },
+  {
+    id: '2',
+    value: 'Green',
+    disabled: false,
+  },
+  {
+    id: '2',
+    value: 'Green',
+    disabled: false,
+  },
+  {
+    id: '2',
+    value: 'Green',
+    disabled: false,
+  },
   { id: '3', value: 'Blue', disabled: false },
   {
     id: '4',

--- a/packages/core/src/global/global.scss
+++ b/packages/core/src/global/global.scss
@@ -77,6 +77,8 @@ Issue: https://github.com/ionic-team/ionic-framework/issues/27500
 */
 
 .select-popover {
+  --max-height: var(--select-max-height, 250px);
+
   &.atom-select__popover {
     .select-interface-option {
       --background-hover: var(--color-neutral-light-5);


### PR DESCRIPTION
[Task](https://juntossomosmais.monday.com/boards/3957397225/pulses/7420027797)

#### What is being delivered?

- Add 250px to default max-height to select
- Create `--select-max-height` to control size inside projects

#### What impacts?

We gained more flexibility to control the size of the element

#### Evidences

<img width="450" alt="image" src="https://github.com/user-attachments/assets/c1ee1526-db71-4a05-8416-c7cf4ce3b460">

