### PR TITLE
fix(button): add white space property to not overflow text

### DIFF
--- a/packages/core/src/components/button/button.scss
+++ b/packages/core/src/components/button/button.scss
@@ -16,6 +16,7 @@
 .atom-button {
   margin: 0;
   text-transform: inherit;
+  white-space: normal;
 
   &[color='white'] {
     --ion-color-base: var(--color-neutral-white);


### PR DESCRIPTION
## Infos

[Task](https://juntossomosmais.monday.com/boards/1521247929/views/139997903/pulses/7599745622)

#### What is being delivered?

Add white-space property to allow text wrap.

#### What impacts?

- Button

#### Reversal plan

Revert this PR.

#### Evidences

| Before | After | 
|--------|------|
| ![Captura de tela 2024-10-09 - 13 55 54](https://github.com/user-attachments/assets/504fa1a6-15c0-48b5-82e9-a0fd5426f358) | ![Captura de tela 2024-10-09 - 13 55 26](https://github.com/user-attachments/assets/5df90aa7-7c3c-4fb3-b5ba-f4a18f6657ae) |

