### PR TITLE
fix(input): dont remove eventlistener on blur/focus

### DIFF
--- a/packages/core/src/components/input/input.tsx
+++ b/packages/core/src/components/input/input.tsx
@@ -119,12 +119,10 @@ export class AtomInput {
   }
 
   private handleBlur = () => {
-    this.inputEl.removeEventListener('ionBlur', this.handleBlur)
     this.atomBlur.emit()
   }
 
   private handleFocus = () => {
-    this.inputEl.removeEventListener('ionFocus', this.handleFocus)
     this.atomFocus.emit()
   }
 


### PR DESCRIPTION
## Infos

<!--

### Pull Request Title Convention

When creating a Pull Request, please follow the title convention. It is essential that the title conforms to the standard as it will be used in the library's changelog description.

> type(context): description

The types should be:
- feat: for new features
- fix: for bug fixes
- chore: for maintenance tasks
- major: for major changes that generate a new version
- docs: for documentation
- ci: for chores about ci changes

Example:
> feat(component): create link component

-->

[Task](https://juntossomosmais.monday.com/boards/1521247929/views/139997903/pulses/7587630449)

#### What is being delivered?

As we are removing the event listener in the "handleBlur" and "handleFocus" methods, libraries that use these events cannot function correctly after the first activation because we remove the event listener.

#### What impacts?

- Input

#### Reversal plan

- Revert

#### Evidences

With fix:

https://github.com/user-attachments/assets/58e97702-5d29-4eb2-a299-0fc6ddd0c960

Without fix, current production branch:

https://github.com/user-attachments/assets/f6b5200b-66f0-495a-9a3f-d917bf776281

