### PR TITLE
fix(container): add box-sizing: border-box to fix size

### DIFF
--- a/packages/core/src/components/container/container.scss
+++ b/packages/core/src/components/container/container.scss
@@ -3,6 +3,7 @@
 /* We need to use !important to override the default styles used by techniques like * { padding: 0, margin: 0 }, it is very common inside projects and override values without !important :( */
 
 :host {
+  box-sizing: border-box;
   display: block;
   margin-left: auto !important;
   margin-right: auto !important;


### PR DESCRIPTION
#### What is being delivered?

- Add `box-sizing: border-box`

#### What impacts?

This prevent container to not works correctly when project don't have `box-sizing: border-box` for all elements

#### Evidences

<img width="767" alt="image" src="https://github.com/user-attachments/assets/c1e75091-054a-4f8b-b49a-ef5f2f7d2411">

