### PR TITLE
fix(modal): set new z index value for modal and steps modal

### DIFF
--- a/packages/core/src/components/modal/modal.scss
+++ b/packages/core/src/components/modal/modal.scss
@@ -1,7 +1,12 @@
 @import '~@atomium/scss-utils/index';
 
+:host {
+  --atom-modal-z-index: var(--zindex-1000);
+}
+
 .atom-modal {
   position: fixed;
+  z-index: var(--atom-modal-z-index) !important;
 
   &__close {
     position: absolute;

--- a/packages/core/src/components/modal/modal.spec.ts
+++ b/packages/core/src/components/modal/modal.spec.ts
@@ -37,7 +37,7 @@ describe('atom-modal', () => {
   it('should render modal with default values', async () => {
     expect(page.root).toEqualHtml(`
       <atom-modal primary-text="Primary" secondary-text="Secondary" trigger="button" disable-primary="true">
-        <ion-modal aria-describedby="atom-modal__content" aria-labelledby="atom-modal__header-title" class="atom-modal" trigger="button">
+        <ion-modal aria-describedby="atom-modal__content" aria-labelledby="atom-modal__header-title" class="atom-modal" part="modal" trigger="button">
           <header class="atom-modal__header" part="header">
             <div id="atom-modal__header-title"></div>
             <atom-button aria-label="close" class="atom-modal__close" fill="clear" shape="circle">

--- a/packages/core/src/components/modal/modal.tsx
+++ b/packages/core/src/components/modal/modal.tsx
@@ -128,6 +128,7 @@ export class AtomModal {
           onDidDismiss={this.handleDidDismiss}
           onDidPresent={this.handleDidPresent}
           isOpen={this.isOpen}
+          part='modal'
         >
           <header part='header' class='atom-modal__header'>
             {iconType && (

--- a/packages/core/src/components/steps-modal/steps-modal.scss
+++ b/packages/core/src/components/steps-modal/steps-modal.scss
@@ -1,14 +1,6 @@
 @import '~@atomium/scss-utils/index';
 
-:host {
-  --atom-steps-modal-z-index: var(--zindex-1000);
-}
-
 .atom-steps-modal {
-  &::part(modal){
-    --atom-modal-z-index: var(--atom-steps-modal-z-index);
-  }
-
   &__step {
     margin-top: var(--spacing-base);
   }

--- a/packages/core/src/components/steps-modal/steps-modal.scss
+++ b/packages/core/src/components/steps-modal/steps-modal.scss
@@ -1,5 +1,15 @@
 @import '~@atomium/scss-utils/index';
 
-.atom-steps-modal__step {
-  margin-top: var(--spacing-base);
+:host {
+  --atom-steps-modal-z-index: var(--zindex-1000);
+}
+
+.atom-steps-modal {
+  &::part(modal){
+    --atom-modal-z-index: var(--atom-steps-modal-z-index);
+  }
+
+  &__step {
+    margin-top: var(--spacing-base);
+  }
 }

--- a/packages/core/src/components/steps-modal/steps-modal.spec.ts
+++ b/packages/core/src/components/steps-modal/steps-modal.spec.ts
@@ -43,6 +43,7 @@ describe('atom-steps-modal', () => {
             has-footer=""
             has-divider=""
             header-title="Step 1"
+            part="steps-modal"
             >
             <div class="atom-steps-modal__step" style="display: block;">
                 <div slot="step-1">Step 1 Content</div>
@@ -162,6 +163,7 @@ describe('atom-steps-modal', () => {
           header-title="Step 1"
           disable-primary=""
           disable-secondary=""
+          part="steps-modal"
           >
           <div class="atom-steps-modal__step" style="display: block;">
               <div slot="step-1">Step 1 Content</div>

--- a/packages/core/src/components/steps-modal/steps-modal.tsx
+++ b/packages/core/src/components/steps-modal/steps-modal.tsx
@@ -133,6 +133,7 @@ export class AtomStepsModal {
             this.atomIsOpenChange.emit(e.detail)
           }}
           class='atom-steps-modal'
+          part='steps-modal'
         >
           {this.stepsTitlesArray.map((title, index) => (
             <div


### PR DESCRIPTION
## Infos

<!--

### Pull Request Title Convention

When creating a Pull Request, please follow the title convention. It is essential that the title conforms to the standard as it will be used in the library's changelog description.

> type(context): description

The types should be:
- feat: for new features
- fix: for bug fixes
- chore: for maintenance tasks
- major: for major changes that generate a new version
- docs: for documentation
- ci: for chores about ci changes

Example:
> feat(component): create link component

-->

[Task](https://juntossomosmais.monday.com/boards/XXX/pulses/XXX)

#### What is being delivered?

Setting the new value for z-index on atom modal, the motivation is that ionic sets it too high and most of other UI libraries doesn't use this value (the value for it before was 20002) 

#### What impacts?

Atom modal component styling and Atom steps modal component

#### Reversal plan

Re release of the previous version and revert on main branch

#### Evidences

Media(images, gifs or videos) that shows the result of your work.
