### PR TITLE
feat(atom-steps-modal): initial step feature

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33331,7 +33331,7 @@
     },
     "packages/core": {
       "name": "@juntossomosmais/atomium",
-      "version": "2.25.0"
+      "version": "2.26.0"
     },
     "packages/icons": {
       "name": "@juntossomosmais/atomium-icons"

--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -195,13 +195,15 @@ export namespace Components {
         "value"?: IonTypes.IonSelect['value'];
     }
     interface AtomStepsModal {
+        "cancelButtonText"?: string;
         "closeOnFinish"?: boolean;
         "currentStep": number;
+        "customInitialStep"?: number;
         "disablePrimaryButton"?: boolean;
         "disableSecondaryButton"?: boolean;
         "isOpen": boolean;
-        "primaryButtonText"?: string;
-        "secondaryButtonText"?: string;
+        "primaryButtonTextsByStep": string;
+        "secondaryButtonTextsByStep": string;
         "steps": number;
         "stepsTitles": string;
         "trigger"?: string;
@@ -825,8 +827,10 @@ declare namespace LocalJSX {
         "value"?: IonTypes.IonSelect['value'];
     }
     interface AtomStepsModal {
+        "cancelButtonText"?: string;
         "closeOnFinish"?: boolean;
         "currentStep"?: number;
+        "customInitialStep"?: number;
         "disablePrimaryButton"?: boolean;
         "disableSecondaryButton"?: boolean;
         "isOpen"?: boolean;
@@ -838,8 +842,8 @@ declare namespace LocalJSX {
         "onAtomIsOpenChange"?: (event: AtomStepsModalCustomEvent<any>) => void;
         "onAtomNextStep"?: (event: AtomStepsModalCustomEvent<any>) => void;
         "onAtomPreviousStep"?: (event: AtomStepsModalCustomEvent<any>) => void;
-        "primaryButtonText"?: string;
-        "secondaryButtonText"?: string;
+        "primaryButtonTextsByStep"?: string;
+        "secondaryButtonTextsByStep"?: string;
         "steps"?: number;
         "stepsTitles"?: string;
         "trigger"?: string;

--- a/packages/core/src/components/steps-modal/steps-modal.spec.ts
+++ b/packages/core/src/components/steps-modal/steps-modal.spec.ts
@@ -348,7 +348,7 @@ describe('atom-steps-modal', () => {
             steps="3"
             trigger="open-modal-steps"
             steps-titles="Step 1, Step 2, Step 3"
-            custom-initial-step="2"
+            locked-initial-step="2"
             primary-button-texts-by-step="Next, Next, Finish"
             secondary-button-texts-by-step="Close, Close, Previous"
         >
@@ -369,7 +369,7 @@ describe('atom-steps-modal', () => {
     expect(cancelSpy).toHaveBeenCalled()
   })
 
-  it('should adjust progress when customInitialStep is set', async () => {
+  it('should adjust progress when locked-initial-step is set', async () => {
     page = await newSpecPage({
       components: [AtomStepsModal],
       html: `
@@ -378,7 +378,7 @@ describe('atom-steps-modal', () => {
             steps="3"
             trigger="open-modal-steps"
             steps-titles="Step 1, Step 2, Step 3"
-            custom-initial-step="2"
+            locked-initial-step="2"
             primary-button-texts-by-step="Next, Next, Finish"
             secondary-button-texts-by-step="Close, Close, Previous"
         >
@@ -390,8 +390,8 @@ describe('atom-steps-modal', () => {
 
     expect(page.rootInstance.progress).toBe(0.5)
   })
-  
-  it('should set customInitialStep to current step when dismiss is called', async () => {
+
+  it('should set locked-initial-step to current step when dismiss is called', async () => {
     page = await newSpecPage({
       components: [AtomStepsModal],
       html: `
@@ -400,7 +400,7 @@ describe('atom-steps-modal', () => {
             steps="3"
             trigger="open-modal-steps"
             steps-titles="Step 1, Step 2, Step 3"
-            custom-initial-step="2"
+            locked-initial-step="2"
             primary-button-texts-by-step="Next, Next, Finish"
             secondary-button-texts-by-step="Close, Close, Previous"
         >

--- a/packages/core/src/components/steps-modal/steps-modal.spec.ts
+++ b/packages/core/src/components/steps-modal/steps-modal.spec.ts
@@ -286,7 +286,7 @@ describe('atom-steps-modal', () => {
       page.root?.querySelector('atom-modal')?.getAttribute('header-title')
     ).toBe('Step 2')
   })
-  
+
   it('should close modal when closeOnFinish is set', async () => {
     page = await newSpecPage({
       components: [AtomStepsModal],
@@ -385,5 +385,35 @@ describe('atom-steps-modal', () => {
     })
 
     expect(page.rootInstance.progress).toBe(0.5)
+  })
+  
+  it('should set customInitialStep to current step when dismiss is called', async () => {
+    page = await newSpecPage({
+      components: [AtomStepsModal],
+      html: `
+        <atom-button id="open-modal-steps">Open Modal</atom-button>
+        <atom-steps-modal
+            steps="3"
+            trigger="open-modal-steps"
+            steps-titles="Step 1, Step 2, Step 3"
+            custom-initial-step="2"
+            primary-button-texts-by-step="Next, Next, Finish"
+            secondary-button-texts-by-step="Close, Close, Previous"
+        >
+        <div slot="step-1">Step 1 Content</div>
+        <div slot="step-2">Step 2 Content</div>
+        <div slot="step-3">Step 3 Content</div>
+      </atom-steps-modal>`,
+    })
+    
+    const mockEventObject = {
+      stopImmediatePropagation: jest.fn(),
+    }
+
+    page.rootInstance.handlePrimaryClick()
+    page.rootInstance.handlePrimaryClick()
+    page.rootInstance.handleDidDismiss(mockEventObject)
+
+    expect(page.rootInstance.currentStep).toBe(2)
   })
 })

--- a/packages/core/src/components/steps-modal/steps-modal.spec.ts
+++ b/packages/core/src/components/steps-modal/steps-modal.spec.ts
@@ -286,6 +286,7 @@ describe('atom-steps-modal', () => {
       page.root?.querySelector('atom-modal')?.getAttribute('header-title')
     ).toBe('Step 2')
   })
+  
   it('should close modal when closeOnFinish is set', async () => {
     page = await newSpecPage({
       components: [AtomStepsModal],
@@ -313,6 +314,7 @@ describe('atom-steps-modal', () => {
 
     expect(page.rootInstance.isOpen).toBe(false)
   })
+
   it('should emit atomIsOpenChange when modal is opened or closed', async () => {
     const isOpenChangeSpy = jest.fn()
 
@@ -336,6 +338,7 @@ describe('atom-steps-modal', () => {
     expect(isOpenChangeSpy).toHaveBeenCalledTimes(2)
     expect(isOpenChangeSpy.mock.calls[1][0].detail).toBe(false)
   })
+
   it('should close the modal when customInitialStep is set and the secondary button is clicked on that step', async () => {
     page = await newSpecPage({
       components: [AtomStepsModal],
@@ -360,5 +363,27 @@ describe('atom-steps-modal', () => {
     await page.waitForChanges()
 
     expect(page.rootInstance.isOpen).toBe(false)
+  })
+
+  it('should adjust progress when customInitialStep is set', async () => {
+    page = await newSpecPage({
+      components: [AtomStepsModal],
+      html: `
+        <atom-button id="open-modal-steps">Open Modal</atom-button>
+        <atom-steps-modal
+            steps="3"
+            trigger="open-modal-steps"
+            steps-titles="Step 1, Step 2, Step 3"
+            custom-initial-step="2"
+            primary-button-texts-by-step="Next, Next, Finish"
+            secondary-button-texts-by-step="Close, Close, Previous"
+        >
+        <div slot="step-1">Step 1 Content</div>
+        <div slot="step-2">Step 2 Content</div>
+        <div slot="step-3">Step 3 Content</div>
+      </atom-steps-modal>`,
+    })
+
+    expect(page.rootInstance.progress).toBe(0.5)
   })
 })

--- a/packages/core/src/components/steps-modal/steps-modal.spec.ts
+++ b/packages/core/src/components/steps-modal/steps-modal.spec.ts
@@ -339,7 +339,7 @@ describe('atom-steps-modal', () => {
     expect(isOpenChangeSpy.mock.calls[1][0].detail).toBe(false)
   })
 
-  it('should close the modal when customInitialStep is set and the secondary button is clicked on that step', async () => {
+  it('should emit atom cancel the modal when customInitialStep is set and the secondary button is clicked on that step', async () => {
     page = await newSpecPage({
       components: [AtomStepsModal],
       html: `
@@ -357,12 +357,16 @@ describe('atom-steps-modal', () => {
         <div slot="step-3">Step 3 Content</div>
       </atom-steps-modal>`,
     })
+    const cancelSpy = jest.fn()
 
-    page.rootInstance.handleSecondaryClick()
+    page.root?.addEventListener('atomCancel', cancelSpy)
 
-    await page.waitForChanges()
+    page.root
+      ?.querySelector('atom-modal')
+      ?.dispatchEvent(new CustomEvent('atomSecondaryClick'))
 
-    expect(page.rootInstance.isOpen).toBe(false)
+    expect(page.rootInstance.currentStep).toBe(2)
+    expect(cancelSpy).toHaveBeenCalled()
   })
 
   it('should adjust progress when customInitialStep is set', async () => {
@@ -405,7 +409,7 @@ describe('atom-steps-modal', () => {
         <div slot="step-3">Step 3 Content</div>
       </atom-steps-modal>`,
     })
-    
+
     const mockEventObject = {
       stopImmediatePropagation: jest.fn(),
     }

--- a/packages/core/src/components/steps-modal/steps-modal.spec.ts
+++ b/packages/core/src/components/steps-modal/steps-modal.spec.ts
@@ -14,8 +14,8 @@ describe('atom-steps-modal', () => {
             steps="3"
             trigger="open-modal-steps"
             steps-titles="Step 1, Step 2, Step 3"
-            primary-button-text="Next"
-            secondary-button-text="Previous"
+            primary-button-texts-by-step="Next, Next, Finish"
+            secondary-button-texts-by-step="Close, Close, Previous"
         >
         <div slot="step-1">Step 1 Content</div>
         <div slot="step-2">Step 2 Content</div>
@@ -27,8 +27,8 @@ describe('atom-steps-modal', () => {
   it('should render modal with default values', async () => {
     expect(page.root).toEqualHtml(`
         <atom-steps-modal
-          primary-button-text="Next"
-          secondary-button-text="Previous"
+          primary-button-texts-by-step="Next, Next, Finish"
+          secondary-button-texts-by-step="Close, Close, Previous"
           steps="3"
           trigger="open-modal-steps"
           steps-titles="Step 1, Step 2, Step 3"
@@ -39,7 +39,7 @@ describe('atom-steps-modal', () => {
             class="atom-steps-modal"
             primary-button-text="Next"
             progress="0.3333333333333333"
-            secondary-button-text="Previous"
+            secondary-button-text="Close"
             has-footer=""
             has-divider=""
             header-title="Step 1"
@@ -129,8 +129,8 @@ describe('atom-steps-modal', () => {
             steps="3"
             trigger="open-modal-steps"
             steps-titles="Step 1, Step 2, Step 3"
-            primary-button-text="Next"
-            secondary-button-text="Previous"
+            primary-button-texts-by-step="Next, Next, Finish"
+            secondary-button-texts-by-step="Close, Close, Previous"
             disable-primary-button
             disable-secondary-button
         >
@@ -143,8 +143,8 @@ describe('atom-steps-modal', () => {
 
     expect(page.root).toEqualHtml(`
       <atom-steps-modal
-        primary-button-text="Next"
-        secondary-button-text="Previous"
+        primary-button-texts-by-step="Next, Next, Finish"
+        secondary-button-texts-by-step="Close, Close, Previous"
         steps="3"
         trigger="open-modal-steps"
         steps-titles="Step 1, Step 2, Step 3"
@@ -157,7 +157,7 @@ describe('atom-steps-modal', () => {
           class="atom-steps-modal"
           primary-button-text="Next"
           progress="0.3333333333333333"
-          secondary-button-text="Previous"
+          secondary-button-text="Close"
           has-footer=""
           has-divider=""
           header-title="Step 1"
@@ -273,6 +273,8 @@ describe('atom-steps-modal', () => {
             trigger="open-modal-steps"
             steps-titles="Step 1, Step 2, Step 3"
             current-step="2"
+            primary-button-texts-by-step="Next, Next, Finish"
+            secondary-button-texts-by-step="Close, Close, Previous"
         >
         <div slot="step-0">Step 1 Content</div>
         <div slot="step-1">Step 2 Content</div>
@@ -294,6 +296,8 @@ describe('atom-steps-modal', () => {
             trigger="open-modal-steps"
             steps-titles="Step 1, Step 2, Step 3"
             close-on-finish
+            primary-button-texts-by-step="Next, Next, Finish"
+            secondary-button-texts-by-step="Close, Close, Previous"
         >
         <div slot="step-1">Step 1 Content</div>
         <div slot="step-2">Step 2 Content</div>
@@ -331,5 +335,30 @@ describe('atom-steps-modal', () => {
 
     expect(isOpenChangeSpy).toHaveBeenCalledTimes(2)
     expect(isOpenChangeSpy.mock.calls[1][0].detail).toBe(false)
+  })
+  it('should close the modal when customInitialStep is set and the secondary button is clicked on that step', async () => {
+    page = await newSpecPage({
+      components: [AtomStepsModal],
+      html: `
+        <atom-button id="open-modal-steps">Open Modal</atom-button>
+        <atom-steps-modal
+            steps="3"
+            trigger="open-modal-steps"
+            steps-titles="Step 1, Step 2, Step 3"
+            custom-initial-step="2"
+            primary-button-texts-by-step="Next, Next, Finish"
+            secondary-button-texts-by-step="Close, Close, Previous"
+        >
+        <div slot="step-1">Step 1 Content</div>
+        <div slot="step-2">Step 2 Content</div>
+        <div slot="step-3">Step 3 Content</div>
+      </atom-steps-modal>`,
+    })
+
+    page.rootInstance.handleSecondaryClick()
+
+    await page.waitForChanges()
+
+    expect(page.rootInstance.isOpen).toBe(false)
   })
 })

--- a/packages/core/src/components/steps-modal/steps-modal.tsx
+++ b/packages/core/src/components/steps-modal/steps-modal.tsx
@@ -53,7 +53,7 @@ export class AtomStepsModal {
       this.currentStep = 1
     }
 
-    if (this.customInitialStep) {
+    if (this.customInitialStep && this.customInitialStep >= 1) {
       this.currentStep = this.customInitialStep
     }
 

--- a/packages/core/src/components/steps-modal/steps-modal.tsx
+++ b/packages/core/src/components/steps-modal/steps-modal.tsx
@@ -136,7 +136,7 @@ export class AtomStepsModal {
 
   private get progress() {
     if(this.customInitialStep) {
-      const currentStepAdjustedAsInitial = this.currentStep - this.customInitialStep
+      const currentStepAdjustedAsInitial = this.currentStep - this.customInitialStep + 1
       const stepsQuantityAjustedToCustomInitial = (this.steps + 1 - this.customInitialStep)
 
       return ( currentStepAdjustedAsInitial / stepsQuantityAjustedToCustomInitial )

--- a/packages/core/src/components/steps-modal/steps-modal.tsx
+++ b/packages/core/src/components/steps-modal/steps-modal.tsx
@@ -24,7 +24,6 @@ export class AtomStepsModal {
   @Prop() disablePrimaryButton?: boolean
   @Prop() disableSecondaryButton?: boolean
   @Prop() customInitialStep?: number
-  @Prop() cancelButtonText?: string
   @Prop() primaryButtonTextsByStep: string
   @Prop() secondaryButtonTextsByStep: string
 
@@ -125,9 +124,7 @@ export class AtomStepsModal {
   }
 
   private get secondaryButtonText() {
-    return this.currentStep === this.customInitialStep
-      ? this.cancelButtonText
-      : this.secondaryButtonTextsArray[this.currentStep - 1].trim()
+    return this.secondaryButtonTextsArray[this.currentStep - 1].trim()
   }
 
   private get primaryButtonText() {
@@ -135,14 +132,14 @@ export class AtomStepsModal {
   }
 
   private get progress() {
-    if(this.customInitialStep) {
-      const currentStepAdjustedAsInitial = this.currentStep - this.customInitialStep + 1
-      const stepsQuantityAjustedToCustomInitial = (this.steps + 1 - this.customInitialStep)
+    if (!this.customInitialStep) return this.currentStep / this.steps
 
-      return ( currentStepAdjustedAsInitial / stepsQuantityAjustedToCustomInitial )
-    }
+    const currentStepAdjustedAsInitial =
+      this.currentStep - this.customInitialStep + 1
+    const stepsQuantityAdjustedToCustomInitial =
+      this.steps + 1 - this.customInitialStep
 
-    return this.currentStep / this.steps
+    return currentStepAdjustedAsInitial / stepsQuantityAdjustedToCustomInitial
   }
 
   render() {

--- a/packages/core/src/components/steps-modal/steps-modal.tsx
+++ b/packages/core/src/components/steps-modal/steps-modal.tsx
@@ -122,7 +122,7 @@ export class AtomStepsModal {
     e.stopImmediatePropagation()
     this.isOpen = false
     this.atomDidDismiss.emit(this.currentStep)
-    this.currentStep = 1
+    this.currentStep = this.customInitialStep ? this.customInitialStep : 1
   }
 
   private get secondaryButtonText() {

--- a/packages/core/src/components/steps-modal/steps-modal.tsx
+++ b/packages/core/src/components/steps-modal/steps-modal.tsx
@@ -96,7 +96,6 @@ export class AtomStepsModal {
 
   private handleSecondaryClick = () => {
     if (this.currentStep === this.customInitialStep) {
-      this.isOpen = false
       this.atomCancel.emit()
 
       return
@@ -122,7 +121,7 @@ export class AtomStepsModal {
     e.stopImmediatePropagation()
     this.isOpen = false
     this.atomDidDismiss.emit(this.currentStep)
-    this.currentStep = this.customInitialStep ? this.customInitialStep : 1
+    this.currentStep = this.customInitialStep ?? 1
   }
 
   private get secondaryButtonText() {
@@ -137,7 +136,10 @@ export class AtomStepsModal {
 
   private get progress() {
     if(this.customInitialStep) {
-      return (this.currentStep - this.customInitialStep + 1) / (this.steps + 1 - this.customInitialStep)
+      const currentStepAdjustedAsInitial = this.currentStep - this.customInitialStep
+      const stepsQuantityAjustedToCustomInitial = (this.steps + 1 - this.customInitialStep)
+
+      return ( currentStepAdjustedAsInitial / stepsQuantityAjustedToCustomInitial )
     }
 
     return this.currentStep / this.steps

--- a/packages/core/src/components/steps-modal/steps-modal.tsx
+++ b/packages/core/src/components/steps-modal/steps-modal.tsx
@@ -135,6 +135,14 @@ export class AtomStepsModal {
     return this.primaryButtonTextsArray[this.currentStep - 1].trim()
   }
 
+  private get progress() {
+    if(this.customInitialStep) {
+      return (this.currentStep - this.customInitialStep + 1) / (this.steps + 1 - this.customInitialStep)
+    }
+
+    return this.currentStep / this.steps
+  }
+
   render() {
     return (
       <Host>
@@ -143,7 +151,7 @@ export class AtomStepsModal {
           alert-type=''
           primary-button-text={this.primaryButtonText}
           secondary-button-text={this.secondaryButtonText}
-          progress={this.currentStep / this.steps}
+          progress={this.progress}
           has-footer=''
           header-title={this.stepsTitlesArray[this.currentStep - 1].trim()}
           disable-primary={this.disablePrimaryButton}

--- a/packages/core/src/components/steps-modal/steps-modal.tsx
+++ b/packages/core/src/components/steps-modal/steps-modal.tsx
@@ -20,11 +20,13 @@ export class AtomStepsModal {
   @Prop() trigger?: string
   @Prop() stepsTitles: string
   @Prop({ mutable: true }) isOpen = false
-  @Prop() primaryButtonText?: string
-  @Prop() secondaryButtonText?: string
   @Prop() closeOnFinish?: boolean
   @Prop() disablePrimaryButton?: boolean
   @Prop() disableSecondaryButton?: boolean
+  @Prop() customInitialStep?: number
+  @Prop() cancelButtonText?: string
+  @Prop() primaryButtonTextsByStep: string
+  @Prop() secondaryButtonTextsByStep: string
 
   @Event() atomFinish: EventEmitter
   @Event() atomCancel: EventEmitter
@@ -38,6 +40,8 @@ export class AtomStepsModal {
   @Element() el!: HTMLElement
 
   private stepsTitlesArray: string[] = []
+  private primaryButtonTextsArray: string[] = []
+  private secondaryButtonTextsArray: string[] = []
 
   componentWillLoad() {
     const isInvalidCurrentStep =
@@ -49,7 +53,13 @@ export class AtomStepsModal {
       this.currentStep = 1
     }
 
+    if (this.customInitialStep) {
+      this.currentStep = this.customInitialStep
+    }
+
     this.stepsTitlesArray = this.stepsTitles.split(',')
+    this.primaryButtonTextsArray = this.primaryButtonTextsByStep.split(',')
+    this.secondaryButtonTextsArray = this.secondaryButtonTextsByStep.split(',')
   }
 
   private handleStep = (step: number) => {
@@ -85,6 +95,13 @@ export class AtomStepsModal {
   }
 
   private handleSecondaryClick = () => {
+    if (this.currentStep === this.customInitialStep) {
+      this.isOpen = false
+      this.atomCancel.emit()
+
+      return
+    }
+
     if (this.currentStep === 1) {
       this.atomCancel.emit()
 
@@ -106,6 +123,16 @@ export class AtomStepsModal {
     this.isOpen = false
     this.atomDidDismiss.emit(this.currentStep)
     this.currentStep = 1
+  }
+
+  private get secondaryButtonText() {
+    return this.currentStep === this.customInitialStep
+      ? this.cancelButtonText
+      : this.secondaryButtonTextsArray[this.currentStep - 1].trim()
+  }
+
+  private get primaryButtonText() {
+    return this.primaryButtonTextsArray[this.currentStep - 1].trim()
   }
 
   render() {

--- a/packages/core/src/components/steps-modal/steps-modal.tsx
+++ b/packages/core/src/components/steps-modal/steps-modal.tsx
@@ -23,7 +23,7 @@ export class AtomStepsModal {
   @Prop() closeOnFinish?: boolean
   @Prop() disablePrimaryButton?: boolean
   @Prop() disableSecondaryButton?: boolean
-  @Prop() customInitialStep?: number
+  @Prop() lockedInitialStep?: number
   @Prop() primaryButtonTextsByStep: string
   @Prop() secondaryButtonTextsByStep: string
 
@@ -52,8 +52,8 @@ export class AtomStepsModal {
       this.currentStep = 1
     }
 
-    if (this.customInitialStep && this.customInitialStep >= 1) {
-      this.currentStep = this.customInitialStep
+    if (this.lockedInitialStep && this.lockedInitialStep >= 1) {
+      this.currentStep = this.lockedInitialStep
     }
 
     this.stepsTitlesArray = this.stepsTitles.split(',')
@@ -94,7 +94,7 @@ export class AtomStepsModal {
   }
 
   private handleSecondaryClick = () => {
-    if (this.currentStep === this.customInitialStep) {
+    if (this.currentStep === this.lockedInitialStep) {
       this.atomCancel.emit()
 
       return
@@ -120,7 +120,7 @@ export class AtomStepsModal {
     e.stopImmediatePropagation()
     this.isOpen = false
     this.atomDidDismiss.emit(this.currentStep)
-    this.currentStep = this.customInitialStep ?? 1
+    this.currentStep = this.lockedInitialStep ?? 1
   }
 
   private get secondaryButtonText() {
@@ -132,12 +132,12 @@ export class AtomStepsModal {
   }
 
   private get progress() {
-    if (!this.customInitialStep) return this.currentStep / this.steps
+    if (!this.lockedInitialStep) return this.currentStep / this.steps
 
     const currentStepAdjustedAsInitial =
-      this.currentStep - this.customInitialStep + 1
+      this.currentStep - this.lockedInitialStep + 1
     const stepsQuantityAdjustedToCustomInitial =
-      this.steps + 1 - this.customInitialStep
+      this.steps + 1 - this.lockedInitialStep
 
     return currentStepAdjustedAsInitial / stepsQuantityAdjustedToCustomInitial
   }

--- a/packages/core/src/components/steps-modal/stories/steps-modal.args.ts
+++ b/packages/core/src/components/steps-modal/stories/steps-modal.args.ts
@@ -144,6 +144,14 @@ export const ModalStoryArgs = {
         category: Category.EVENTS,
       },
     },
+    customInitialStep: {
+      control: 'number',
+      description:
+        'The index of the step that the modal will start on. If the user tries to go back further than the custom initial step, the modal closes itself. Default value is 1',
+      table: {
+        category: Category.PROPERTIES,
+      },
+    },
     step_x: {
       name: 'step-x',
       description:
@@ -170,6 +178,7 @@ export const ModalComponentArgs = {
   currentStep: 1,
   isOpen: false,
   closeOnFinish: false,
-  primaryButtonText: 'Next',
-  secondaryButtonText: 'Previous',
+  primaryButtonTextsByStep: 'Continue, Continue, Finish',
+  secondaryButtonTextsByStep: 'Close, Back, Back',
+  customInitialStep: 1,
 }

--- a/packages/core/src/components/steps-modal/stories/steps-modal.args.ts
+++ b/packages/core/src/components/steps-modal/stories/steps-modal.args.ts
@@ -144,14 +144,15 @@ export const ModalStoryArgs = {
         category: Category.EVENTS,
       },
     },
-    customInitialStep: {
+    lockedInitialStep: {
       control: 'number',
       description:
-        'The index of the step that the modal will start on. If the user tries to go back further than the custom initial step, the modal closes itself. Default value is 1',
+        'Specifies the step index at which the modal will start. Users are restricted from navigating to steps before this index. Attempting to go back beyond this step will emit atom cancel event from the modal.',
       table: {
         category: Category.PROPERTIES,
       },
     },
+
     step_x: {
       name: 'step-x',
       description:
@@ -180,5 +181,5 @@ export const ModalComponentArgs = {
   closeOnFinish: false,
   primaryButtonTextsByStep: 'Continue, Continue, Finish',
   secondaryButtonTextsByStep: 'Close, Back, Back',
-  customInitialStep: 1,
+  lockedInitialStep: 1,
 }

--- a/packages/core/src/components/steps-modal/stories/steps-modal.core.stories.tsx
+++ b/packages/core/src/components/steps-modal/stories/steps-modal.core.stories.tsx
@@ -15,12 +15,14 @@ const createModal = (args) => {
       <atom-steps-modal
         steps="3"
         trigger="open-modal-steps"
-        steps-titles="Step 1, Step 2, Step 3"
+        steps-titles="${args.stepsTitles}"
         current-step="${args.currentStep}"
         close-on-finish="${args.closeOnFinish}"
-        primary-button-text="${args.primaryButtonText}"
-        secondary-button-text="${args.secondaryButtonText}"
+        primary-button-texts-by-step="${args.primaryButtonTextsByStep}"
+        secondary-button-texts-by-step="${args.secondaryButtonTextsByStep}"
         is-open="${args.isOpen}"
+        custom-initial-step="${args.customInitialStep}"
+        cancel-button-text="Close"
       >
         <div slot="step-1">Step 1 Content</div>
         <div slot="step-2">Step 2 Content</div>
@@ -42,6 +44,14 @@ export const CurrentStepAlreadySet: StoryObj = {
   args: {
     ...ModalComponentArgs,
     currentStep: 2,
+  },
+}
+
+export const CustomInitialStep: StoryObj = {
+  render: (args) => createModal(args),
+  args: {
+    ...ModalComponentArgs,
+    customInitialStep: 2,
   },
 }
 

--- a/packages/core/src/components/steps-modal/stories/steps-modal.core.stories.tsx
+++ b/packages/core/src/components/steps-modal/stories/steps-modal.core.stories.tsx
@@ -22,7 +22,6 @@ const createModal = (args) => {
         secondary-button-texts-by-step="${args.secondaryButtonTextsByStep}"
         is-open="${args.isOpen}"
         custom-initial-step="${args.customInitialStep}"
-        cancel-button-text="Close"
       >
         <div slot="step-1">Step 1 Content</div>
         <div slot="step-2">Step 2 Content</div>

--- a/packages/core/src/components/steps-modal/stories/steps-modal.react.stories.tsx
+++ b/packages/core/src/components/steps-modal/stories/steps-modal.react.stories.tsx
@@ -18,8 +18,8 @@ const createModal = (args) => (
       trigger='open-modal-steps'
       steps-titles={args.stepsTitles}
       close-on-finish={args.closeOnFinish}
-      primaryButtonText={args.primaryButtonText}
-      secondaryButtonText={args.secondaryButtonText}
+      primaryButtonTextsByStep={args.primaryButtonTextsByStep}
+      secondaryButtonTextsByStep={args.secondaryButtonTextsByStep}
     >
       <div slot='step-1'>Step 1 Content</div>
       <div slot='step-2'>Step 2 Content</div>
@@ -40,6 +40,14 @@ export const CurrentStepAlreadySet: StoryObj = {
   args: {
     ...ModalComponentArgs,
     currentStep: 2,
+  },
+}
+
+export const CustomInitialStep: StoryObj = {
+  render: (args) => createModal(args),
+  args: {
+    ...ModalComponentArgs,
+    customInitialStep: 2,
   },
 }
 

--- a/packages/core/src/components/steps-modal/stories/steps-modal.vue.stories.tsx
+++ b/packages/core/src/components/steps-modal/stories/steps-modal.vue.stories.tsx
@@ -21,8 +21,8 @@ const createModal = (args, themeColor = 'light') => ({
         trigger="open-modal-steps"
         steps-titles="${args.stepsTitles}"
         close-on-finish="${args.closeOnFinish}"
-        primary-button-text="${args.primaryButtonText}"
-        secondary-button-text="${args.secondaryButtonText}"
+        primary-button-texts-by-step="${args.primaryButtonTextsByStep}"
+        secondary-button-texts-by-step="${args.secondaryButtonTextsByStep}"
         is-open="${args.isOpen}"
       >
         <div slot="step-1">Step 1 Content</div>
@@ -45,6 +45,14 @@ export const CurrentStepAlreadySet: StoryObj = {
   args: {
     ...ModalComponentArgs,
     currentStep: 2,
+  },
+}
+
+export const CustomInitialStep: StoryObj = {
+  render: (args) => createModal(args),
+  args: {
+    ...ModalComponentArgs,
+    customInitialStep: 2,
   },
 }
 


### PR DESCRIPTION
## Infos

<!--

### Pull Request Title Convention

When creating a Pull Request, please follow the title convention. It is essential that the title conforms to the standard as it will be used in the library's changelog description.

> type(context): description

The types should be:
- feat: 

Example:
> feat(component): create link component

-->

[Task](https://juntossomosmais.monday.com/boards/XXX/pulses/XXX)

#### What is being delivered?

adding new property to allow user to start the modal directly in a specific step even though it has more steps behind.
Change the use of primaryButtonText and secondaryButtonText to be an array of string for each step, like the titles.
Change the name of this properties to be more descriptive with the purpose

#### What impacts?



BREAKING CHANGE: Atom steps modal component and primaryButton and secondaryButton texts functionalities, the primaryButtonText and secondaryButtonText properties don't will exists by now on.

#### Reversal plan

Re-release of the previous version and revert on main branch.

#### Evidences

Media(images, gifs or videos) that shows the result of your work.
[Gravação de tela de 22-11-2024 11:21:28.webm](https://github.com/user-attachments/assets/1a91fce3-5811-4981-8636-aaeb431dec82)
