### PR TITLE
fix(pagination): edge case when count is equal a 1

### DIFF
--- a/packages/core/src/components/pagination/pagination.spec.tsx
+++ b/packages/core/src/components/pagination/pagination.spec.tsx
@@ -53,6 +53,18 @@ describe('atom-pagination', () => {
     ])
   })
 
+  it('generates correct pagination items when count is equal or less 1', async () => {
+    const page = await newSpecPage({
+      components: [AtomPagination],
+      html: `<atom-pagination page="1" count="1"></atom-pagination>`,
+    })
+
+    const pagination = page.rootInstance
+    const items = pagination.makeItems()
+
+    expect(items).toEqual([{ type: 'page', number: 1 }])
+  })
+
   it('generates correct boundary pagination items', async () => {
     const page = await newSpecPage({
       components: [AtomPagination],

--- a/packages/core/src/components/pagination/pagination.tsx
+++ b/packages/core/src/components/pagination/pagination.tsx
@@ -38,6 +38,12 @@ export class AtomPagination {
   makeItems() {
     const items = []
 
+    if (this.count <= 1) {
+      items.push({ type: 'page', number: 1 })
+
+      return items
+    }
+
     const siblingsStart = Math.max(
       Math.min(
         this.page - this.sibling,


### PR DESCRIPTION
## Infos

<!--

### Pull Request Title Convention

When creating a Pull Request, please follow the title convention. It is essential that the title conforms to the standard as it will be used in the library's changelog description.

> type(context): description

The types should be:
- feat: for new features
- fix: for bug fixes
- chore: for maintenance tasks
- major: for major changes that generate a new version
- docs: for documentation
- ci: for chores about ci changes

Example:
> feat(component): create link component

-->

[Task](https://juntossomosmais.monday.com/boards/XXX/pulses/XXX)

#### What is being delivered?

Minor fix on pagination when page count is less or equal a one, the bug in question was due to boundary pages.


#### What impacts?

- Pagination

#### Reversal plan

- Revert PR


#### Evidences


<img width="1063" alt="Captura de Tela 2024-12-06 às 13 26 25" src="https://github.com/user-attachments/assets/122b25bc-65ea-4187-9eff-2c6dc62bc363">

<img width="1080" alt="Captura de Tela 2024-12-06 às 13 27 01" src="https://github.com/user-attachments/assets/754701a1-e0a0-49da-9113-e3a630815094">
