### PR TITLE
fix(select): prevent clicks on non-interactive elements inside ion-select to ensure correct popover size

### DIFF
--- a/packages/core/src/components/select/select.spec.ts
+++ b/packages/core/src/components/select/select.spec.ts
@@ -347,9 +347,9 @@ describe('AtomSelect', () => {
 
     await page.waitForChanges()
     const mockFiltered = optionsMock.filter((option) => option?.tag?.label)
-    const instanceObjetct = page.rootInstance.filterOptionsWithTag(optionsMock)
+    const instanceObject = page.rootInstance.filterOptionsWithTag(optionsMock)
 
-    expect(Object.keys(instanceObjetct).length).toEqual(mockFiltered.length)
+    expect(Object.keys(instanceObject).length).toEqual(mockFiltered.length)
   })
   it('should filter options and attach tag element', async () => {
     const page = await newSpecPage({

--- a/packages/core/src/components/select/select.tsx
+++ b/packages/core/src/components/select/select.tsx
@@ -135,7 +135,12 @@ export class AtomSelect {
     this.selectEl.removeEventListener('ionDismiss', this.handleDismiss)
   }
 
-  /* In some cases each elements inside `ion-select` are clickable individually, so it causes a bug to open the popover, for example, when click on arrow icon the popover is opened extremely small. This method is a workaround to fix this bug. */
+  /*
+   * In some cases, individual elements inside `ion-select` are clickable, causing the popover to open with an incorrect size.
+   * For example, clicking on the arrow icon can result in a very small options overlay, leading to a poor user experience.
+   * This method is a workaround to fix this issue by adding `pointer-events: none` to elements inside the `ion-select`
+   * that are not the `label` or `icon`, ensuring a consistent overlay size.
+   */
   private applyPointerEventsNone() {
     const ionSelect = this.selectEl?.shadowRoot?.querySelector('ion-select')
     const selectWrapper =

--- a/packages/core/src/components/select/select.tsx
+++ b/packages/core/src/components/select/select.tsx
@@ -128,10 +128,22 @@ export class AtomSelect {
 
   componentDidLoad() {
     this.selectEl.addEventListener('ionDismiss', this.handleDismiss)
+    this.applyPointerEventsNone()
   }
 
   disconnectedCallback() {
     this.selectEl.removeEventListener('ionDismiss', this.handleDismiss)
+  }
+
+  /* In some cases each elements inside `ion-select` are clickable individually, so it causes a bug to open the popover, for example, when click on arrow icon the popover is opened extremely small. This method is a workaround to fix this bug. */
+  private applyPointerEventsNone() {
+    const ionSelect = this.selectEl?.shadowRoot?.querySelector('ion-select')
+    const selectWrapper =
+      ionSelect?.shadowRoot?.querySelector('.select-wrapper')
+
+    if (selectWrapper) {
+      (selectWrapper as HTMLElement).style.pointerEvents = 'none'
+    }
   }
 
   private handleChange: IonTypes.IonSelect['onIonChange'] = (event) => {


### PR DESCRIPTION
#### What is being delivered?

In some cases, when a user clicks on an individual element inside an `ion-select`, the size of the ion-popover changes unexpectedly. For example, clicking on the arrow icon of the `ion-select` can cause the options overlay to become very small, leading to a poor user experience.

To prevent these extra clicks and ensure a consistent overlay size, the proposed solution is to add pointer-events: none to elements inside the ion-select that are not the label or icon.

Since ion-select is a web component, we must access its shadow DOM to apply this style.

#### What impacts?

- Users will be unable to click on individual elements inside the `ion-select` that are not the label or icon. This ensures that the popover opens with the correct size and prevents unexpected behavior, leading to a more consistent and improved user experience.

#### Reversal plan

- Remove the `pointer-events: none` from the elements inside the `ion-select`.

