### PR TITLE
fix(docs): adjust tokens table doc

### DIFF
--- a/packages/tokens/stories/2_Spacings.mdx
+++ b/packages/tokens/stories/2_Spacings.mdx
@@ -1,5 +1,4 @@
 import { Meta } from '@storybook/blocks'
-
 import Table from './components/Table.jsx'
 
 <Meta title='Tokens/Spacings' />

--- a/packages/tokens/stories/2_Spacings.mdx
+++ b/packages/tokens/stories/2_Spacings.mdx
@@ -1,22 +1,27 @@
 import { Meta } from '@storybook/blocks'
 
-<Meta title="Tokens/Spacings" />
+import Table from './components/Table.jsx'
+
+<Meta title='Tokens/Spacings' />
 
 # Spacings
 
 All spacings are defined as `--spacing-*` CSS variables.
 
-| Size | Variable                   |
-| ---- | -------------------------- |
-| 4px  | `var(--spacing-xxsmall)`   |
-| 8px  | `var(--spacing-xsmall)`    |
-| 12px | `var(--spacing-small)`     |
-| 16px | `var(--spacing-base)`      |
-| 20px | `var(--spacing-medium)`    |
-| 24px | `var(--spacing-large)`     |
-| 28px | `var(--spacing-xlarge)`    |
-| 32px | `var(--spacing-xxlarge)`   |
-| 40px | `var(--spacing-xxxlarge)`  |
-| 48px | `var(--spacing-xxxxlarge)` |
-| 64px | `var(--spacing-giant)`     |
-| 80px | `var(--spacing-xgiant)`    |
+<Table
+  headers={['Size', 'Variable']}
+  rows={[
+    ['4px', 'var(--spacing-xxsmall)'],
+    ['8px', 'var(--spacing-xsmall)'],
+    ['12px', 'var(--spacing-small)'],
+    ['16px', 'var(--spacing-base)'],
+    ['20px', 'var(--spacing-medium)'],
+    ['24px', 'var(--spacing-large)'],
+    ['28px', 'var(--spacing-xlarge)'],
+    ['32px', 'var(--spacing-xxlarge)'],
+    ['40px', 'var(--spacing-xxxlarge)'],
+    ['48px', 'var(--spacing-xxxxlarge)'],
+    ['64px', 'var(--spacing-giant)'],
+    ['80px', 'var(--spacing-xgiant)'],
+  ]}
+/>

--- a/packages/tokens/stories/3_Typography.mdx
+++ b/packages/tokens/stories/3_Typography.mdx
@@ -1,6 +1,8 @@
 import { Meta, Typeset } from '@storybook/blocks'
 
-<Meta title="Tokens/Typography" />
+import Table from './components/Table.jsx'
+
+<Meta title='Tokens/Typography' />
 
 # Typography
 
@@ -26,7 +28,7 @@ All typography tokens available in the design system.
     '46px',
     '52px',
   ]}
-  sampleText="Atomium is the best!"
+  sampleText='Atomium is the best!'
 />
 
 ## Using
@@ -35,31 +37,40 @@ Tokens could be used as CSS Variables or CSS Classes.
 
 ### Variable values
 
-| Variable                   | Font weight | font-size/line-height | Mobile    | Letter Spacing |
-| -------------------------- | ----------- | --------------------- | --------- | -------------- |
-| `--title-giant`            | 700         | 52px/68px             | 30px/40px | 0.25%            |
-| `--title-display`          | 700         | 46px/60px             | 28px/36px | 0.25%            |
-| `--title-headline-xxlarge` | 700         | 42px/56px             | 26px/36px | 0.25%            |
-| `--title-headline-xlarge`  | 700         | 36px/48px             | 25px/32px | 0.25%            |
-| `--title-headline-large`   | 700         | 32px/40px             | 24px/32px | 0.25%            |
-| `--title-headline-medium`  | 700         | 28px/36px             | 22px/28px | 0.15%            |
-| `--title-headline-small`   | 700         | 26px/36px             | 20px/28px | 0.15%            |
-| `--title-headline-xsmall`  | 700         | 22px/28px             | 19px/24px | 0.15%            |
-| `--text-subtitle-large`    | 700         | 20px/28px             | 18px/24px | 0.15%            |
-| `--text-subtitle-medium`   | 700         | 18px/24px             | 16px/20px | 0.1%             |
-| `--text-body-large`        | 400         | 18px/28px             | 18px/28px | 0.5%             |
-| `--text-body-medium`       | 400         | 16px/24px             | 16px/24px | 0.5%             |
-| `--text-body-small`        | 400         | 14px/24px             | 14px/24px | 0.25%            |
-| `--text-link-large`        | 700         | 18px/28px             | 18px/28px | 0.5%             |
-| `--text-link-medium`       | 700         | 16px/24px             | 16px/24px | 0.5%             |
-| `--text-link-small`        | 700         | 14px/24px             | 14px/24px | 0.25%            |
-| `--button-large`           | 700         | 18px/28px             | 18px/28px | 8%             |
-| `--button-medium`          | 700         | 16px/24px             | 16px/24px | 8%             |
-| `--button-small`           | 700         | 14px/20px             | 14px/20px | 8%             |
-| `--text-caption`           | 400         | 12px/20px             | 14px/24px | 0.4%             |
-| `--text-caption-focused`   | 700         | 12px/20px             | 14px/24px | 0.4%           |
-| `--text-overline`          | 400         | 11px/20px             | 13px/20px | 16%            |
-| `--text-badge`             | 700         | 10px/16px             | 12px/20px | 4%           |
+<Table
+  headers={[
+    'Variable',
+    'Font weight',
+    'font-size/line-height',
+    'Mobile',
+    'Letter Spacing',
+  ]}
+  rows={[
+    ['--title-giant', '700', '52px/68px', '30px/40px', '0.25%'],
+    ['--title-display', '700', '46px/60px', '28px/36px', '0.25%'],
+    ['--title-headline-xxlarge', '700', '42px/56px', '26px/36px', '0.25%'],
+    ['--title-headline-xlarge', '700', '36px/48px', '25px/32px', '0.25%'],
+    ['--title-headline-large', '700', '32px/40px', '24px/32px', '0.25%'],
+    ['--title-headline-medium', '700', '28px/36px', '22px/28px', '0.15%'],
+    ['--title-headline-small', '700', '26px/36px', '20px/28px', '0.15%'],
+    ['--title-headline-xsmall', '700', '22px/28px', '19px/24px', '0.15%'],
+    ['--text-subtitle-large', '700', '20px/28px', '18px/24px', '0.15%'],
+    ['--text-subtitle-medium', '700', '18px/24px', '16px/20px', '0.1%'],
+    ['--text-body-large', '400', '18px/28px', '18px/28px', '0.5%'],
+    ['--text-body-medium', '400', '16px/24px', '16px/24px', '0.5%'],
+    ['--text-body-small', '400', '14px/24px', '14px/24px', '0.25%'],
+    ['--text-link-large', '700', '18px/28px', '18px/28px', '0.5%'],
+    ['--text-link-medium', '700', '16px/24px', '16px/24px', '0.5%'],
+    ['--text-link-small', '700', '14px/24px', '14px/24px', '0.25%'],
+    ['--button-large', '700', '18px/28px', '18px/28px', '8%'],
+    ['--button-medium', '700', '16px/24px', '16px/24px', '8%'],
+    ['--button-small', '700', '14px/20px', '14px/20px', '8%'],
+    ['--text-caption', '400', '12px/20px', '14px/24px', '0.4%'],
+    ['--text-caption-focused', '700', '12px/20px', '14px/24px', '0.4%'],
+    ['--text-overline', '400', '11px/20px', '13px/20px', '16%'],
+    ['--text-badge', '700', '10px/16px', '12px/20px', '4%'],
+  ]}
+/>
 
 #### !important
 
@@ -69,13 +80,17 @@ All the `letter-spacing` variable is the font + letter, example: `var(--title-gi
 
 ### Font family
 
-| Variable             | Value                 |
-| -------------------- | --------------------- |
-| `var(--font-family)` | 'Roboto', sans-serif' |
+<Table
+  headers={['Variable', 'Value']}
+  rows={[['var(--font-family)', "'Roboto', sans-serif'"]]}
+/>
 
 ### Font weight
 
-| Variable                     | Value |
-| ---------------------------- | ----- |
-| `var(--font-weight-regular)` | 400   |
-| `var(--font-weight-bold)`    | 700   |
+<Table
+  headers={['Variable', 'Value']}
+  rows={[
+    ['var(--font-family)', "'Roboto', sans-serif'"],
+    ['var(--font-weight-bold)', '700'],
+  ]}
+/>

--- a/packages/tokens/stories/3_Typography.mdx
+++ b/packages/tokens/stories/3_Typography.mdx
@@ -1,5 +1,4 @@
 import { Meta, Typeset } from '@storybook/blocks'
-
 import Table from './components/Table.jsx'
 
 <Meta title='Tokens/Typography' />

--- a/packages/tokens/stories/4_Screens.mdx
+++ b/packages/tokens/stories/4_Screens.mdx
@@ -1,34 +1,43 @@
 import { Meta } from '@storybook/blocks'
 
-<Meta title="Tokens/Screens" />
+import Table from './components/Table.jsx'
+
+<Meta title='Tokens/Screens' />
 
 # Screens
 
 All breakpoints used in our projects.
 
-| Range          | Screens     |
-| -------------- | ----------- |
-| 0 - 575px      | Extra Small |
-| 576px - 767px  | Small       |
-| 768px - 991px  | Medium      |
-| 992px - 1199px | Large       |
-| >= 1200px      | Extra Large |
+<Table
+  headers={['Range', 'Screens']}
+  rows={[
+    ['0 - 575px ', 'Extra Small'],
+    ['576px - 767px', 'Small'],
+    ['768px - 991px', 'Medium'],
+    ['992px - 1199px', 'Large'],
+    ['>= 1200px', 'Extra Large'],
+  ]}
+/>
 
 ## Variables
 
-| Size   | Variable            |
-| ------ | ------------------- |
-| 576px  | `var(--screen-xs)`  |
-| 768px  | `var(--screen-sm)`  |
-| 992px  | `var(--screen-md)`  |
-| 1200px | `var(--screen-lg)`  |
-| 1440px | `var(--screen-xlg)` |
-| 1920px | `var(--screen-fhd)` |
-| 2048px | `var(--screen-2k)`  |
-| 3840px | `var(--screen-4k)`  |
+<Table
+  headers={['Size', 'Variable']}
+  rows={[
+    ['576px', 'var(--screen-xs)'],
+    ['768px', 'var(--screen-sm)'],
+    ['992px', 'var(--screen-md)'],
+    ['1200px', 'var(--screen-lg)'],
+    ['1440px', 'var(--screen-xlg)'],
+    ['1920px', 'var(--screen-fhd)'],
+    ['2048px', 'var(--screen-2k)'],
+    ['3840px', 'var(--screen-4k)'],
+  ]}
+/>
 
 We also has a variable to define the max size of containers.
 
-| Size   | Variable                      |
-| ------ | ----------------------------- |
-| 1136px | `var(--screen-max-container)` |
+<Table
+  headers={['Size', 'Variable']}
+  rows={[['1136px', 'var(--screen-max-container)']]}
+/>

--- a/packages/tokens/stories/4_Screens.mdx
+++ b/packages/tokens/stories/4_Screens.mdx
@@ -1,5 +1,4 @@
 import { Meta } from '@storybook/blocks'
-
 import Table from './components/Table.jsx'
 
 <Meta title='Tokens/Screens' />

--- a/packages/tokens/stories/5_Grid.mdx
+++ b/packages/tokens/stories/5_Grid.mdx
@@ -1,6 +1,8 @@
 import { Meta } from '@storybook/blocks'
 
-<Meta title="Tokens/Grid" />
+import Table from './components/Table.jsx'
+
+<Meta title='Tokens/Grid' />
 
 # Grid
 
@@ -8,19 +10,25 @@ The [default grid system](/docs/components-grid--docs) is based on a `16` column
 
 ## Tokens
 
-| Variable              | Value                 |
-| --------------------- | --------------------- |
-| `var(--grid-gap)`     | `var(--spacing-base)` |
-| `var(--grid-columns)` | `12`                  |
+<Table
+  headers={['Variable', 'Value']}
+  rows={[
+    ['var(--grid-gap)', 'var(--spacing-base)'],
+    ['var(--grid-columns)', '12'],
+  ]}
+/>
 
 ## Grid Patterns
 
 You could check our [screen sizes here](/docs/tokens-screen-sizes--docs).
 
-| Breakpoint  | Container        | Columns | Gutter | External Margin |
-| ----------- | ---------------- | ------- | ------ | --------------- |
-| Extra Small | Fluid            | 4       | 8px    | 16px            |
-| Small       | Fluid            | 8       | 8px    | 16px            |
-| Medium      | Fluid            | 8       | 24px   | 16px            |
-| Large       | Fluid            | 16      | 32px   | 16px            |
-| Extra Large | Fixed (`1136px`) | 16      | auto   | 16px            |
+<Table
+  headers={['Breakpoint', 'Container', 'Columns', 'Gutter', 'External Margin']}
+  rows={[
+    ['Extra Small', 'Fluid', '4', '8px', '16px'],
+    ['Small', 'Fluid', '8', '8px', '16px'],
+    ['Medium', 'Fluid', '8', '24px', '16px'],
+    ['Large', 'Fluid', '16', '32px', '16px'],
+    ['Extra Large', 'Fixed (1136px)', '16', 'auto', '16px'],
+  ]}
+/>

--- a/packages/tokens/stories/5_Grid.mdx
+++ b/packages/tokens/stories/5_Grid.mdx
@@ -1,5 +1,4 @@
 import { Meta } from '@storybook/blocks'
-
 import Table from './components/Table.jsx'
 
 <Meta title='Tokens/Grid' />

--- a/packages/tokens/stories/6_Misc.mdx
+++ b/packages/tokens/stories/6_Misc.mdx
@@ -1,6 +1,5 @@
 import { Meta } from '@storybook/blocks'
 import { Box, BoxList } from './components/Box.jsx'
-
 import Table from './components/Table.jsx'
 
 <Meta title='Tokens/Misc' />

--- a/packages/tokens/stories/6_Misc.mdx
+++ b/packages/tokens/stories/6_Misc.mdx
@@ -1,7 +1,9 @@
 import { Meta } from '@storybook/blocks'
 import { Box, BoxList } from './components/Box.jsx'
 
-<Meta title="Tokens/Misc" />
+import Table from './components/Table.jsx'
+
+<Meta title='Tokens/Misc' />
 
 # Miscellaneous
 
@@ -11,12 +13,31 @@ In our Design System, most components have rounded edges. Depending on the size 
 
 ### Variants
 
-| value | Variable                      | Description                                                                                                   |
-| ----- | ----------------------------- | ------------------------------------------------------------------------------------------------------------- |
-| 4px   | `var(--border-radius)`        | Used in smaller components like tooltips, alerts, text fields.                                                |
-| 8px   | `var(--border-radius-medium)` | Used in larger components like dialogs, cards and dropdown menu.                                              |
-| 12px  | `var(--border-radius-large)`  | Depending on the context, the this border radius can also be used on larger components like cards and images. |
-| 50%   | `var(--border-radius-full)`   | The fully rounded edge is used for specific components like buttons, badges and avatars.                      |
+<Table
+  headers={['Variable', 'Value', 'Description']}
+  rows={[
+    [
+      'var(--border-radius)',
+      '4px',
+      'Used in smaller components like tooltips, alerts, text fields.',
+    ],
+    [
+      'var(--border-radius-medium)',
+      '8px',
+      'Used in larger components like dialogs, cards and dropdown menu.',
+    ],
+    [
+      'var(--border-radius-large)',
+      '12px',
+      'Depending on the context, this border radius can also be used on larger components like cards and images.',
+    ],
+    [
+      'var(--border-radius-full)',
+      '50%',
+      'The fully rounded edge is used for specific components like buttons, badges and avatars.',
+    ],
+  ]}
+/>
 
 ### Usage
 
@@ -27,9 +48,9 @@ This token must be used **only** with `border-radius` CSS property.
 <BoxList>
   <Box borderRadius="var(--border-radius)" />
 
-  <Box borderRadius="var(--border-radius-medium)" />
+<Box borderRadius='var(--border-radius-medium)' />
 
-  <Box borderRadius="var(--border-radius-large)" />
+<Box borderRadius='var(--border-radius-large)' />
 
   <Box borderRadius="var(--border-radius-full)" />
 </BoxList>
@@ -38,18 +59,22 @@ This token must be used **only** with `border-radius` CSS property.
 
 The default `transition-duration` for all transitions
 
-| value | Variable                     |
-| ----- | ---------------------------- |
-| 0.25s | `var(--transition-duration)` |
+<Table
+  headers={['Variable', 'Value']}
+  rows={[['var(--transition-duration)', '0.25s']]}
+/>
 
 ## z-index
 
 All `z-index` variables to keep consistency
 
-| value | Variable                |
-| ----- | ----------------------- |
-| 1     | `var(--zindex-1)`       |
-| 10    | `var(--zindex-10)`      |
-| 100   | `var(--zindex-100)`     |
-| 1000  | `var(--zindex-1000)`    |
-| 10000 | `var(--zindex-overlay)` |
+<Table
+  headers={['Variable', 'Value']}
+  rows={[
+    [1, 'var(--zindex-1)'],
+    [10, 'var(--zindex-100)'],
+    [100, 'var(--zindex-100)'],
+    [1000, 'var(--zindex-1000)'],
+    [10000, 'var(--zindex-overlay)'],
+  ]}
+/>

--- a/packages/tokens/stories/7_Elevation.mdx
+++ b/packages/tokens/stories/7_Elevation.mdx
@@ -1,7 +1,8 @@
 import { Meta } from '@storybook/blocks'
 import { Box, BoxList } from './components/Box.jsx'
+import Table from './components/Table.jsx'
 
-<Meta title="Tokens/Elevation" />
+<Meta title='Tokens/Elevation' />
 
 # Elevation
 
@@ -11,16 +12,45 @@ Elevation indicates how far the interface elements are from the surface and dete
 
 To get a more natural shadow effect, we use overlapping of two or more shadows on each token. Elevation values range from 0 to 8dp, as shown in the table below:
 
-| Value                                                                                                 | Variable             |
-| ----------------------------------------------------------------------------------------------------- | -------------------- |
-| 0px 1px 1px rgba(0, 0, 0, 0.14)                                                                       | `var(--elevation-1)` |
-| 0px 1px 5px rgba(0, 0, 0, 0.12), 0px 2px 2px rgba(0, 0, 0, 0.14)                                      | `var(--elevation-2)` |
-| 0px 1px 10px rgba(0, 0, 0, 0.12), 0px 4px 5px rgba(0, 0, 0, 0.14), 0px 2px 4px rgba(0, 0, 0, 0.2)     | `var(--elevation-3)` |
-| 0px 1px 18px rgba(0, 0, 0, 0.12), 0px 6px 10px rgba(0, 0, 0, 0.14), 0px 3px 5px rgba(0, 0, 0, 0.2)    | `var(--elevation-4)` |
-| 0px 5px 22px rgba(0, 0, 0, 0.12), 0px 12px 17px rgba(0, 0, 0, 0.14), 0px 7px 8px rgba(0, 0, 0, 0.2)   | `var(--elevation-5)` |
-| 0px 6px 30px rgba(0, 0, 0, 0.12), 0px 16px 24px rgba(0, 0, 0, 0.14), 0px 8px 10px rgba(0, 0, 0, 0.2)  | `var(--elevation-6)` |
-| 0px 8px 38px rgba(0, 0, 0, 0.12), 0px 20px 31px rgba(0, 0, 0, 0.14), 0px 10px 13px rgba(0, 0, 0, 0.2) | `var(--elevation-7)` |
-| 0px 9px 46px rgba(0, 0, 0, 0.12), 0px 24px 38px rgba(0, 0, 0, 0.14), 0px 11px 15px rgba(0, 0, 0, 0.2) | `var(--elevation-8)` |
+<Table
+  headers={['Variable', 'Value']}
+  rows={[
+    ['var(--elevation-1)', '0px 1px 1px rgba(0, 0, 0, 0.14)'],
+    [
+      'var(--elevation-2)',
+      '0px 1px 5px rgba(0, 0, 0, 0.12), 0px 2px 2px rgba(0, 0, 0, 0.14)',
+    ],
+    [
+      'var(--elevation-3)',
+      '0px 1px 10px rgba(0, 0, 0, 0.12), 0px 4px 5px rgba(0, 0, 0, 0.14), 0px 2px 4px rgba(0, 0, 0, 0.2)',
+    ],
+    [
+      'var(--elevation-4)',
+      '0px 1px 18px rgba(0, 0, 0, 0.12), 0px 6px 10px rgba(0, 0, 0, 0.14), 0px 3px 5px rgba(0, 0, 0, 0.2)',
+    ],
+    [
+      'var(--elevation-5)',
+      '0px 5px 22px rgba(0, 0, 0, 0.12), 0px 12px 17px rgba(0, 0, 0, 0.14), 0px 7px 8px rgba(0, 0, 0, 0.2)',
+    ],
+    [
+      'var(--elevation-6)',
+      '0px 6px 30px rgba(0, 0, 0, 0.12), 0px 16px 24px rgba(0, 0, 0, 0.14), 0px 8px 10px rgba(0, 0, 0, 0.2)',
+    ],
+    [
+      'var(--elevation-7)',
+      '0px 8px 38px rgba(0, 0, 0, 0.12), 0px 20px 31px rgba(0, 0, 0, 0.14), 0px 10px 13px rgba(0, 0, 0, 0.2)',
+    ],
+    [
+      'var(--elevation-8)',
+      '0px 9px 46px rgba(0, 0, 0, 0.12), 0px 24px 38px rgba(0, 0, 0, 0.14), 0px 11px 15px rgba(0, 0, 0, 0.2)',
+    ],
+    ['var(--zindex-1)', '1'],
+    ['var(--zindex-10)', '10'],
+    ['var(--zindex-100)', '100'],
+    ['var(--zindex-1000)', '1000'],
+    ['var(--zindex-overlay)', '10000'],
+  ]}
+/>
 
 ## Usage
 
@@ -38,17 +68,17 @@ filter: drop-shadow(var(--elevation-8));
 <BoxList>
   <Box elevation="--elevation-1" />
 
-  <Box elevation="--elevation-2" />
+<Box elevation='--elevation-2' />
 
-  <Box elevation="--elevation-3" />
+<Box elevation='--elevation-3' />
 
-  <Box elevation="--elevation-4" />
+<Box elevation='--elevation-4' />
 
-  <Box elevation="--elevation-5" />
+<Box elevation='--elevation-5' />
 
-  <Box elevation="--elevation-6" />
+<Box elevation='--elevation-6' />
 
-  <Box elevation="--elevation-7" />
+<Box elevation='--elevation-7' />
 
   <Box elevation="--elevation-8" />
 </BoxList>

--- a/packages/tokens/stories/components/Box.jsx
+++ b/packages/tokens/stories/components/Box.jsx
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-unused-vars
 import React, { Children } from 'react'
 
 export const Box = ({ elevation, borderRadius }) => {

--- a/packages/tokens/stories/components/Table.jsx
+++ b/packages/tokens/stories/components/Table.jsx
@@ -1,0 +1,25 @@
+/* eslint-disable no-unused-vars */
+import React from 'react'
+
+const Table = ({ headers, rows }) => (
+  <table>
+    <thead>
+      <tr>
+        {headers.map((header, index) => (
+          <th key={index}>{header}</th>
+        ))}
+      </tr>
+    </thead>
+    <tbody>
+      {rows.map((row, rowIndex) => (
+        <tr key={rowIndex}>
+          {row.map((cell, cellIndex) => (
+            <td key={cellIndex}>{cell}</td>
+          ))}
+        </tr>
+      ))}
+    </tbody>
+  </table>
+)
+
+export default Table

--- a/packages/tokens/stories/components/Table.jsx
+++ b/packages/tokens/stories/components/Table.jsx
@@ -1,4 +1,4 @@
-/* eslint-disable no-unused-vars */
+// eslint-disable-next-line no-unused-vars
 import React from 'react'
 
 const Table = ({ headers, rows }) => (


### PR DESCRIPTION
## Infos

<!--

### Pull Request Title Convention

When creating a Pull Request, please follow the title convention. It is essential that the title conforms to the standard as it will be used in the library's changelog description.

> type(context): description

The types should be:
- feat: for new features
- fix: for bug fixes
- chore: for maintenance tasks
- major: for major changes that generate a new version
- docs: for documentation
- ci: for chores about ci changes

Example:
> feat(component): create link component

-->

[Task](https://juntossomosmais.monday.com/boards/3345740155/views/76424285/pulses/8487208067)

#### What is being delivered?

This pull request includes several changes to improve the readability and maintainability of the documentation by replacing static HTML tables with a reusable `Table` component and fixing some minor issues. The most important changes include updating multiple story files to use the new `Table` component and making minor formatting adjustments.

### Use of Table Component:

* [`packages/tokens/stories/components/Table.jsx`](diffhunk://#diff-74107f284f1bb66c2c0d8848b847eef9f340a73e5358d44f64b10a9c67763a91R1-R25): Created a new `Table` component to replace static HTML tables across the documentation. Ref: https://github.com/storybookjs/storybook/discussions/22613#discussioncomment-5975074


* [`packages/tokens/stories/2_Spacings.mdx`](diffhunk://#diff-91349565fcd65e6b1b16b4bd68e997aa6bd11de198855514e0df3e5b1dea6dbbR2-R26): Replaced the static HTML table with the new `Table` component to display spacing variables.
* [`packages/tokens/stories/3_Typography.mdx`](diffhunk://#diff-407ebe00a444d20a77782b374df8289ba0a78f66cbba5844d1ebcb1c8e6d0c86R2-R4): Updated the file to use the `Table` component for displaying typography variables and values. [[1]](diffhunk://#diff-407ebe00a444d20a77782b374df8289ba0a78f66cbba5844d1ebcb1c8e6d0c86R2-R4) [[2]](diffhunk://#diff-407ebe00a444d20a77782b374df8289ba0a78f66cbba5844d1ebcb1c8e6d0c86L38-R72) [[3]](diffhunk://#diff-407ebe00a444d20a77782b374df8289ba0a78f66cbba5844d1ebcb1c8e6d0c86L72-R95)
* [`packages/tokens/stories/4_Screens.mdx`](diffhunk://#diff-0d23bea499a04c83bc5c3fac331c98091ea3ca359a011f5816764225a2dfdd2cR2-R42): Integrated the `Table` component to show screen size variables and breakpoints.
* [`packages/tokens/stories/5_Grid.mdx`](diffhunk://#diff-d556dcc0784640fb93448e6cda77f82e0c5d56c8b0f3483b751f0122352b0992R2-R33): Modified the file to utilize the `Table` component for grid-related variables and patterns.
* [`packages/tokens/stories/6_Misc.mdx`](diffhunk://#diff-b0b53c536e33d358b37a15bbeb0b95905e482e1cb081fc9165b6d7a2763deeedR3-R5): Converted the static HTML tables to use the `Table` component for miscellaneous tokens. [[1]](diffhunk://#diff-b0b53c536e33d358b37a15bbeb0b95905e482e1cb081fc9165b6d7a2763deeedR3-R5) [[2]](diffhunk://#diff-b0b53c536e33d358b37a15bbeb0b95905e482e1cb081fc9165b6d7a2763deeedL14-R39) [[3]](diffhunk://#diff-b0b53c536e33d358b37a15bbeb0b95905e482e1cb081fc9165b6d7a2763deeedL41-R79)

### Minor Adjustments:

* [`packages/tokens/stories/3_Typography.mdx`](diffhunk://#diff-407ebe00a444d20a77782b374df8289ba0a78f66cbba5844d1ebcb1c8e6d0c86L29-R30): Changed double quotes to single quotes for consistency in `sampleText` and other text fields.
* [`packages/tokens/stories/7_Elevation.mdx`](diffhunk://#diff-27c93da5e0b4074d16aa52c8f0086b674c5f1aa4bc95ed903aac3ec23416aaceL14-R53): Updated the file to use the `Table` component for elevation variables and adjusted the elevation box elements to use single quotes. [[1]](diffhunk://#diff-27c93da5e0b4074d16aa52c8f0086b674c5f1aa4bc95ed903aac3ec23416aaceL14-R53) [[2]](diffhunk://#diff-27c93da5e0b4074d16aa52c8f0086b674c5f1aa4bc95ed903aac3ec23416aaceL41-R81)
* [`packages/tokens/stories/components/Box.jsx`](diffhunk://#diff-7fb569b04d4d29174c6ab1acd55f2acfce078eba3a27a13a55af7923cb8081ccR1): Added an ESLint directive to ignore unused variables.

#### What impacts?

Stories

#### Reversal plan

Revert the PR

#### Evidences

| Before | After |
| - | - |
| ![image](https://github.com/user-attachments/assets/f3abb84f-ce9d-4de9-b46b-984042291311) | ![image](https://github.com/user-attachments/assets/3324d439-631a-4188-8a0c-75fe690699a9) |