### PR TITLE
fix(atom-link): adjust prop size when type is button in atom-link

### DIFF
--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -227,7 +227,7 @@ export namespace Components {
         "count": number;
         "page": number;
     }
-    interface AtomRichTooltip {
+    interface AtomPopover {
         "action": 'hover' | 'click';
         "actionText"?: string;
         "element": string;
@@ -394,9 +394,9 @@ export interface AtomPaginationCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLAtomPaginationElement;
 }
-export interface AtomRichTooltipCustomEvent<T> extends CustomEvent<T> {
+export interface AtomPopoverCustomEvent<T> extends CustomEvent<T> {
     detail: T;
-    target: HTMLAtomRichTooltipElement;
+    target: HTMLAtomPopoverElement;
 }
 export interface AtomSelectCustomEvent<T> extends CustomEvent<T> {
     detail: T;
@@ -647,22 +647,22 @@ declare global {
         prototype: HTMLAtomPaginationElement;
         new (): HTMLAtomPaginationElement;
     };
-    interface HTMLAtomRichTooltipElementEventMap {
+    interface HTMLAtomPopoverElementEventMap {
         "buttonAction": void;
     }
-    interface HTMLAtomRichTooltipElement extends Components.AtomRichTooltip, HTMLStencilElement {
-        addEventListener<K extends keyof HTMLAtomRichTooltipElementEventMap>(type: K, listener: (this: HTMLAtomRichTooltipElement, ev: AtomRichTooltipCustomEvent<HTMLAtomRichTooltipElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+    interface HTMLAtomPopoverElement extends Components.AtomPopover, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLAtomPopoverElementEventMap>(type: K, listener: (this: HTMLAtomPopoverElement, ev: AtomPopoverCustomEvent<HTMLAtomPopoverElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
         addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
         addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
         addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
-        removeEventListener<K extends keyof HTMLAtomRichTooltipElementEventMap>(type: K, listener: (this: HTMLAtomRichTooltipElement, ev: AtomRichTooltipCustomEvent<HTMLAtomRichTooltipElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLAtomPopoverElementEventMap>(type: K, listener: (this: HTMLAtomPopoverElement, ev: AtomPopoverCustomEvent<HTMLAtomPopoverElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
         removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
         removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
         removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
-    var HTMLAtomRichTooltipElement: {
-        prototype: HTMLAtomRichTooltipElement;
-        new (): HTMLAtomRichTooltipElement;
+    var HTMLAtomPopoverElement: {
+        prototype: HTMLAtomPopoverElement;
+        new (): HTMLAtomPopoverElement;
     };
     interface HTMLAtomSelectElementEventMap {
         "atomBlur": void;
@@ -780,7 +780,7 @@ declare global {
         "atom-meter": HTMLAtomMeterElement;
         "atom-modal": HTMLAtomModalElement;
         "atom-pagination": HTMLAtomPaginationElement;
-        "atom-rich-tooltip": HTMLAtomRichTooltipElement;
+        "atom-popover": HTMLAtomPopoverElement;
         "atom-select": HTMLAtomSelectElement;
         "atom-spinner": HTMLAtomSpinnerElement;
         "atom-steps-modal": HTMLAtomStepsModalElement;
@@ -1023,12 +1023,12 @@ declare namespace LocalJSX {
         "onAtomChangePage"?: (event: AtomPaginationCustomEvent<number>) => void;
         "page"?: number;
     }
-    interface AtomRichTooltip {
+    interface AtomPopover {
         "action"?: 'hover' | 'click';
         "actionText"?: string;
         "element"?: string;
         "label"?: string;
-        "onButtonAction"?: (event: AtomRichTooltipCustomEvent<void>) => void;
+        "onButtonAction"?: (event: AtomPopoverCustomEvent<void>) => void;
         "open"?: boolean;
         "placement"?: | 'top'
     | 'top-start'
@@ -1196,7 +1196,7 @@ declare namespace LocalJSX {
         "atom-meter": AtomMeter;
         "atom-modal": AtomModal;
         "atom-pagination": AtomPagination;
-        "atom-rich-tooltip": AtomRichTooltip;
+        "atom-popover": AtomPopover;
         "atom-select": AtomSelect;
         "atom-spinner": AtomSpinner;
         "atom-steps-modal": AtomStepsModal;
@@ -1229,7 +1229,7 @@ declare module "@stencil/core" {
             "atom-meter": LocalJSX.AtomMeter & JSXBase.HTMLAttributes<HTMLAtomMeterElement>;
             "atom-modal": LocalJSX.AtomModal & JSXBase.HTMLAttributes<HTMLAtomModalElement>;
             "atom-pagination": LocalJSX.AtomPagination & JSXBase.HTMLAttributes<HTMLAtomPaginationElement>;
-            "atom-rich-tooltip": LocalJSX.AtomRichTooltip & JSXBase.HTMLAttributes<HTMLAtomRichTooltipElement>;
+            "atom-popover": LocalJSX.AtomPopover & JSXBase.HTMLAttributes<HTMLAtomPopoverElement>;
             "atom-select": LocalJSX.AtomSelect & JSXBase.HTMLAttributes<HTMLAtomSelectElement>;
             "atom-spinner": LocalJSX.AtomSpinner & JSXBase.HTMLAttributes<HTMLAtomSpinnerElement>;
             "atom-steps-modal": LocalJSX.AtomStepsModal & JSXBase.HTMLAttributes<HTMLAtomStepsModalElement>;

--- a/packages/core/src/components/link/link.spec.ts
+++ b/packages/core/src/components/link/link.spec.ts
@@ -54,7 +54,7 @@ describe('atom-link', () => {
     expect(page.root).toEqualHtml(`
       <atom-link color="secondary" type="button">
         <mock:shadow-root>
-        <button class="atom-link__button">
+        <button class="atom-link--medium atom-link__button">
           <span class="atom-link" color="secondary">
             <slot></slot>
           </span>

--- a/packages/core/src/components/link/link.tsx
+++ b/packages/core/src/components/link/link.tsx
@@ -43,6 +43,7 @@ export class AtomLink {
             class={{
               [`atom-link__button`]: true,
               [`is-loading`]: this.loading,
+              [`atom-link--${this.size}`]: true,
             }}
             onClick={this.handleClick.bind(this)}
           >


### PR DESCRIPTION
[Task](https://juntossomosmais.monday.com/boards/3345740155/views/76424285/pulses/8550568856)

## Summary

This pull request includes changes to the `AtomLink` component in the `packages/core/src/components/link` directory, focusing on enhancing the button's styling based on its size.

Styling improvements:

* [`packages/core/src/components/link/link.tsx`](diffhunk://#diff-dec6bb46efde8bc968dbbcd4cf71706fad0bb7202711d91c5f8350b0c4ad530fR46): Added a dynamic class to the button element to apply size-specific styles (`atom-link--${this.size}`).
* [`packages/core/src/components/link/link.spec.ts`](diffhunk://#diff-9cf748cf7c138423d2d7626ec9c56ea86a5bac4c5522566fd826170e9044b384L57-R57): Updated the test to reflect the new class name `atom-link--medium` added to the button element.

## Evidences

Before

https://github.com/user-attachments/assets/af57288f-50fa-4e41-a4e6-bcba6092a66d

After

https://github.com/user-attachments/assets/474616f1-3558-41cf-8abc-b721302946c2
