### PR TITLE
feat(modal): add metadata prop allowing automated tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21226,7 +21226,7 @@
     },
     "packages/core": {
       "name": "@juntossomosmais/atomium",
-      "version": "3.6.0"
+      "version": "3.6.2"
     },
     "packages/icons": {
       "name": "@juntossomosmais/atomium-icons"

--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -14,11 +14,23 @@ export { LocalJSX as IonTypes } from "@ionic/core/dist/types/components";
 export namespace Components {
     interface AtomAlert {
         "actionText"?: string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "action-text"?: string;
         "close": boolean;
         "color"?: 'info' | 'success' | 'warning' | 'danger' | 'neutral';
         "icon"?: IconProps;
         "messageText"?: string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "message-text"?: string;
         "messageTitle"?: string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "message-title"?: string;
     }
     interface AtomBadge {
         "type": | 'primary'
@@ -54,7 +66,15 @@ export namespace Components {
     interface AtomCarousel {
         "autoplay": number;
         "hasNavigation": boolean;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "has-navigation"?: boolean;
         "hasPagination": boolean;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "has-pagination"?: boolean;
         "loop": boolean;
         "thumbnails": string[];
     }
@@ -71,55 +91,151 @@ export namespace Components {
     interface AtomCol {
         "offset"?: string;
         "offsetLg"?: string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "offset-lg"?: string;
         "offsetMd"?: string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "offset-md"?: string;
         "offsetSm"?: string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "offset-sm"?: string;
         "pull"?: string;
         "push"?: string;
         "size"?: 'auto' | string;
         "sizeLg"?: string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "size-lg"?: string;
         "sizeMd"?: string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "size-md"?: string;
         "sizeSm"?: string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "size-sm"?: string;
     }
     interface AtomContainer {
         "hasPadding": boolean;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "has-padding"?: boolean;
     }
     interface AtomDatetime {
         "cancelText"?: string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "cancel-text"?: string;
         "clearText"?: string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "clear-text"?: string;
         "datetimeId": string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "datetime-id"?: string;
         "dayValues"?: number[] | string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "day-values"?: number[] | string;
         "disabled"?: boolean;
         "doneText"?: string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "done-text"?: string;
         "formatOptions": {
     date?: Intl.DateTimeFormatOptions
     time?: Intl.DateTimeFormatOptions
   };
         "highlightedDates"?: DatetimeHighlight[] | DatetimeHighlightCallback;
         "hourCycle": 'h12' | 'h23';
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "hour-cycle"?: 'h12' | 'h23';
         "hourValues"?: number[] | string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "hour-values"?: number[] | string;
         "isDateEnabled"?: (dateString: string) => boolean;
         "label"?: string;
         "locale": string;
         "max"?: string;
         "min"?: string;
         "minuteValues"?: number[] | string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "minute-values"?: number[] | string;
         "monthValues"?: number[] | string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "month-values"?: number[] | string;
         "multiple"?: boolean;
         "name"?: string;
         "preferWheel": boolean;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "prefer-wheel"?: boolean;
         "presentation"?: DatetimePresentation;
         "rangeMode"?: boolean;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "range-mode"?: boolean;
         "readonly"?: boolean;
         "setValue": (value: any) => Promise<void>;
         "showClearButton"?: boolean;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "show-clear-button"?: boolean;
         "showDefaultButtons"?: boolean;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "show-default-buttons"?: boolean;
         "showDefaultTimeLabel": boolean;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "show-default-time-label"?: boolean;
         "showDefaultTitle": boolean;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "show-default-title"?: boolean;
         "size"?: 'cover' | 'fixed';
         "useButton": boolean;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "use-button"?: boolean;
         "value"?: | DatetimeCustomEvent
     | DatetimeChangeEventDetail;
         "yearValues"?: number[] | string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "year-values"?: number[] | string;
     }
     interface AtomDivider {
         "type": 'horizontal' | 'vertical';
@@ -136,7 +252,15 @@ export namespace Components {
         "autocomplete"?: 'on' | 'off';
         "autofocus": boolean;
         "clearInput": boolean;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "clear-input"?: boolean;
         "clearOnEdit": boolean;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "clear-on-edit"?: boolean;
         "color"?: 'primary' | 'secondary' | 'danger';
         "counter": boolean;
         "counterFormatter"?: (
@@ -152,11 +276,33 @@ export namespace Components {
     | 'previous'
     | 'search'
     | 'send';
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "enter-key-hint"?: | 'enter'
+    | 'done'
+    | 'go'
+    | 'next'
+    | 'previous'
+    | 'search'
+    | 'send';
         "errorText"?: string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "error-text"?: string;
         "fill": 'solid' | 'outline';
         "getInputElement": () => Promise<HTMLInputElement>;
         "hasError": boolean;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "has-error"?: boolean;
         "helperText"?: string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "helper-text"?: string;
         "icon"?: IconProps;
         "inputmode"?: | 'none'
     | 'text'
@@ -168,6 +314,10 @@ export namespace Components {
     | 'search';
         "label"?: string;
         "labelPlacement"?: 'stacked' | 'floating';
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "label-placement"?: 'stacked' | 'floating';
         "max"?: string | number;
         "maxlength"?: number;
         "min"?: string | number;
@@ -176,6 +326,10 @@ export namespace Components {
         "multiple": boolean;
         "name"?: string;
         "passwordToggle": boolean;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "password-toggle"?: boolean;
         "pattern"?: string;
         "placeholder"?: string;
         "readonly": boolean;
@@ -196,12 +350,20 @@ export namespace Components {
     interface AtomListSlider {
         "centralized": boolean;
         "hasNavigation": boolean;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "has-navigation"?: boolean;
     }
     interface AtomListSliderItem {
     }
     interface AtomMeter {
         "actual": number;
         "hasCenterTitle"?: boolean;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "has-center-title"?: boolean;
         "max": number;
         "min": number;
         "size"?: 'small' | 'large';
@@ -210,17 +372,62 @@ export namespace Components {
     }
     interface AtomModal {
         "alertType"?: 'alert' | 'error';
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "alert-type"?: 'alert' | 'error';
         "canDismiss"?: boolean;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "can-dismiss"?: boolean;
         "disablePrimaryButton": boolean;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "disable-primary-button"?: boolean;
         "disableSecondaryButton": boolean;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "disable-secondary-button"?: boolean;
         "hasDivider": boolean;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "has-divider"?: boolean;
         "hasFooter": boolean;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "has-footer"?: boolean;
         "headerTitle": string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "header-title"?: string;
         "idName"?: string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "id-name"?: string;
         "isOpen": boolean;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "is-open"?: boolean;
+        "metaData"?: MetaData;
         "primaryButtonText"?: string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "primary-button-text"?: string;
         "progress"?: number;
         "secondaryButtonText"?: string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "secondary-button-text"?: string;
         "trigger"?: string;
     }
     interface AtomPagination {
@@ -230,6 +437,10 @@ export namespace Components {
     interface AtomPopover {
         "action": 'hover' | 'click';
         "actionText"?: string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "action-text"?: string;
         "element": string;
         "label"?: string;
         "open": boolean;
@@ -245,8 +456,16 @@ export namespace Components {
     interface AtomSelect {
         "disabled"?: boolean;
         "errorText"?: string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "error-text"?: string;
         "fill": 'solid' | 'outline';
         "helperText"?: string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "helper-text"?: string;
         "icon"?: IconProps;
         "label"?: string;
         "mode": Mode;
@@ -271,28 +490,80 @@ export namespace Components {
     }
     interface AtomStepsModal {
         "closeOnFinish"?: boolean;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "close-on-finish"?: boolean;
         "currentStep": number;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "current-step"?: number;
         "disablePrimaryButton"?: boolean;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "disable-primary-button"?: boolean;
         "disableSecondaryButton"?: boolean;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "disable-secondary-button"?: boolean;
         "isOpen": boolean;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "is-open"?: boolean;
         "lockedInitialStep"?: number;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "locked-initial-step"?: number;
         "primaryButtonTextsByStep": string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "primary-button-texts-by-step"?: string;
         "secondaryButtonTextsByStep": string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "secondary-button-texts-by-step"?: string;
         "steps": number;
         "stepsTitles": string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "steps-titles"?: string;
         "trigger"?: string;
     }
     interface AtomTag {
         "color": 'success' | 'danger' | 'warning' | 'info' | 'dark' | 'light';
         "customBackgroundColor"?: string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "custom-background-color"?: string;
         "customTextColor"?: string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "custom-text-color"?: string;
         "icon"?: IconProps;
     }
     interface AtomTextarea {
         "autoGrow": boolean;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "auto-grow"?: boolean;
         "autocomplete"?: 'on' | 'off';
         "autofocus": boolean;
         "clearOnEdit": boolean;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "clear-on-edit"?: boolean;
         "color"?: 'primary' | 'secondary' | 'danger';
         "cols"?: number;
         "counter": boolean;
@@ -309,11 +580,33 @@ export namespace Components {
     | 'previous'
     | 'search'
     | 'send';
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "enter-key-hint"?: | 'enter'
+    | 'done'
+    | 'go'
+    | 'next'
+    | 'previous'
+    | 'search'
+    | 'send';
         "errorText"?: string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "error-text"?: string;
         "fill": 'solid' | 'outline';
         "getInputElement": () => Promise<HTMLTextAreaElement>;
         "hasError": boolean;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "has-error"?: boolean;
         "helperText"?: string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "helper-text"?: string;
         "icon"?: IconProps;
         "inputmode"?: | 'none'
     | 'text'
@@ -325,6 +618,10 @@ export namespace Components {
     | 'search';
         "label"?: string;
         "labelPlacement"?: 'stacked' | 'floating';
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "label-placement"?: 'stacked' | 'floating';
         "maxlength"?: number;
         "minlength"?: number;
         "mode": Mode;
@@ -792,11 +1089,23 @@ declare global {
 declare namespace LocalJSX {
     interface AtomAlert {
         "actionText"?: string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "action-text"?: string;
         "close"?: boolean;
         "color"?: 'info' | 'success' | 'warning' | 'danger' | 'neutral';
         "icon"?: IconProps;
         "messageText"?: string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "message-text"?: string;
         "messageTitle"?: string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "message-title"?: string;
         "onAtomAction"?: (event: AtomAlertCustomEvent<any>) => void;
         "onAtomClose"?: (event: AtomAlertCustomEvent<any>) => void;
     }
@@ -835,7 +1144,15 @@ declare namespace LocalJSX {
     interface AtomCarousel {
         "autoplay"?: number;
         "hasNavigation"?: boolean;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "has-navigation"?: boolean;
         "hasPagination"?: boolean;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "has-pagination"?: boolean;
         "loop"?: boolean;
         "thumbnails"?: string[];
     }
@@ -853,39 +1170,103 @@ declare namespace LocalJSX {
     interface AtomCol {
         "offset"?: string;
         "offsetLg"?: string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "offset-lg"?: string;
         "offsetMd"?: string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "offset-md"?: string;
         "offsetSm"?: string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "offset-sm"?: string;
         "pull"?: string;
         "push"?: string;
         "size"?: 'auto' | string;
         "sizeLg"?: string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "size-lg"?: string;
         "sizeMd"?: string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "size-md"?: string;
         "sizeSm"?: string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "size-sm"?: string;
     }
     interface AtomContainer {
         "hasPadding"?: boolean;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "has-padding"?: boolean;
     }
     interface AtomDatetime {
         "cancelText"?: string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "cancel-text"?: string;
         "clearText"?: string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "clear-text"?: string;
         "datetimeId"?: string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "datetime-id"?: string;
         "dayValues"?: number[] | string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "day-values"?: number[] | string;
         "disabled"?: boolean;
         "doneText"?: string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "done-text"?: string;
         "formatOptions"?: {
     date?: Intl.DateTimeFormatOptions
     time?: Intl.DateTimeFormatOptions
   };
         "highlightedDates"?: DatetimeHighlight[] | DatetimeHighlightCallback;
         "hourCycle"?: 'h12' | 'h23';
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "hour-cycle"?: 'h12' | 'h23';
         "hourValues"?: number[] | string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "hour-values"?: number[] | string;
         "isDateEnabled"?: (dateString: string) => boolean;
         "label"?: string;
         "locale"?: string;
         "max"?: string;
         "min"?: string;
         "minuteValues"?: number[] | string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "minute-values"?: number[] | string;
         "monthValues"?: number[] | string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "month-values"?: number[] | string;
         "multiple"?: boolean;
         "name"?: string;
         "onAtomBlur"?: (event: AtomDatetimeCustomEvent<void>) => void;
@@ -893,18 +1274,50 @@ declare namespace LocalJSX {
         "onAtomChange"?: (event: AtomDatetimeCustomEvent<string | string[]>) => void;
         "onAtomFocus"?: (event: AtomDatetimeCustomEvent<void>) => void;
         "preferWheel"?: boolean;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "prefer-wheel"?: boolean;
         "presentation"?: DatetimePresentation;
         "rangeMode"?: boolean;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "range-mode"?: boolean;
         "readonly"?: boolean;
         "showClearButton"?: boolean;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "show-clear-button"?: boolean;
         "showDefaultButtons"?: boolean;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "show-default-buttons"?: boolean;
         "showDefaultTimeLabel"?: boolean;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "show-default-time-label"?: boolean;
         "showDefaultTitle"?: boolean;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "show-default-title"?: boolean;
         "size"?: 'cover' | 'fixed';
         "useButton"?: boolean;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "use-button"?: boolean;
         "value"?: | DatetimeCustomEvent
     | DatetimeChangeEventDetail;
         "yearValues"?: number[] | string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "year-values"?: number[] | string;
     }
     interface AtomDivider {
         "type"?: 'horizontal' | 'vertical';
@@ -921,7 +1334,15 @@ declare namespace LocalJSX {
         "autocomplete"?: 'on' | 'off';
         "autofocus"?: boolean;
         "clearInput"?: boolean;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "clear-input"?: boolean;
         "clearOnEdit"?: boolean;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "clear-on-edit"?: boolean;
         "color"?: 'primary' | 'secondary' | 'danger';
         "counter"?: boolean;
         "counterFormatter"?: (
@@ -937,10 +1358,32 @@ declare namespace LocalJSX {
     | 'previous'
     | 'search'
     | 'send';
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "enter-key-hint"?: | 'enter'
+    | 'done'
+    | 'go'
+    | 'next'
+    | 'previous'
+    | 'search'
+    | 'send';
         "errorText"?: string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "error-text"?: string;
         "fill"?: 'solid' | 'outline';
         "hasError"?: boolean;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "has-error"?: boolean;
         "helperText"?: string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "helper-text"?: string;
         "icon"?: IconProps;
         "inputmode"?: | 'none'
     | 'text'
@@ -952,6 +1395,10 @@ declare namespace LocalJSX {
     | 'search';
         "label"?: string;
         "labelPlacement"?: 'stacked' | 'floating';
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "label-placement"?: 'stacked' | 'floating';
         "max"?: string | number;
         "maxlength"?: number;
         "min"?: string | number;
@@ -964,6 +1411,10 @@ declare namespace LocalJSX {
         "onAtomFocus"?: (event: AtomInputCustomEvent<void>) => void;
         "onAtomInput"?: (event: AtomInputCustomEvent<string>) => void;
         "passwordToggle"?: boolean;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "password-toggle"?: boolean;
         "pattern"?: string;
         "placeholder"?: string;
         "readonly"?: boolean;
@@ -983,6 +1434,10 @@ declare namespace LocalJSX {
     interface AtomListSlider {
         "centralized"?: boolean;
         "hasNavigation"?: boolean;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "has-navigation"?: boolean;
         "onClickNext"?: (event: AtomListSliderCustomEvent<any>) => void;
         "onClickPrev"?: (event: AtomListSliderCustomEvent<any>) => void;
     }
@@ -991,6 +1446,10 @@ declare namespace LocalJSX {
     interface AtomMeter {
         "actual"?: number;
         "hasCenterTitle"?: boolean;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "has-center-title"?: boolean;
         "max"?: number;
         "min"?: number;
         "size"?: 'small' | 'large';
@@ -999,14 +1458,51 @@ declare namespace LocalJSX {
     }
     interface AtomModal {
         "alertType"?: 'alert' | 'error';
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "alert-type"?: 'alert' | 'error';
         "canDismiss"?: boolean;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "can-dismiss"?: boolean;
         "disablePrimaryButton"?: boolean;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "disable-primary-button"?: boolean;
         "disableSecondaryButton"?: boolean;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "disable-secondary-button"?: boolean;
         "hasDivider"?: boolean;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "has-divider"?: boolean;
         "hasFooter"?: boolean;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "has-footer"?: boolean;
         "headerTitle"?: string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "header-title"?: string;
         "idName"?: string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "id-name"?: string;
         "isOpen"?: boolean;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "is-open"?: boolean;
+        "metaData"?: MetaData;
         "onAtomCloseClick"?: (event: AtomModalCustomEvent<any>) => void;
         "onAtomDidDismiss"?: (event: AtomModalCustomEvent<any>) => void;
         "onAtomDidPresent"?: (event: AtomModalCustomEvent<any>) => void;
@@ -1014,8 +1510,16 @@ declare namespace LocalJSX {
         "onAtomPrimaryClick"?: (event: AtomModalCustomEvent<any>) => void;
         "onAtomSecondaryClick"?: (event: AtomModalCustomEvent<any>) => void;
         "primaryButtonText"?: string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "primary-button-text"?: string;
         "progress"?: number;
         "secondaryButtonText"?: string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "secondary-button-text"?: string;
         "trigger"?: string;
     }
     interface AtomPagination {
@@ -1026,6 +1530,10 @@ declare namespace LocalJSX {
     interface AtomPopover {
         "action"?: 'hover' | 'click';
         "actionText"?: string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "action-text"?: string;
         "element"?: string;
         "label"?: string;
         "onButtonAction"?: (event: AtomPopoverCustomEvent<void>) => void;
@@ -1042,8 +1550,16 @@ declare namespace LocalJSX {
     interface AtomSelect {
         "disabled"?: boolean;
         "errorText"?: string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "error-text"?: string;
         "fill"?: 'solid' | 'outline';
         "helperText"?: string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "helper-text"?: string;
         "icon"?: IconProps;
         "label"?: string;
         "mode"?: Mode;
@@ -1072,11 +1588,35 @@ declare namespace LocalJSX {
     }
     interface AtomStepsModal {
         "closeOnFinish"?: boolean;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "close-on-finish"?: boolean;
         "currentStep"?: number;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "current-step"?: number;
         "disablePrimaryButton"?: boolean;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "disable-primary-button"?: boolean;
         "disableSecondaryButton"?: boolean;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "disable-secondary-button"?: boolean;
         "isOpen"?: boolean;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "is-open"?: boolean;
         "lockedInitialStep"?: number;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "locked-initial-step"?: number;
         "onAtomCancel"?: (event: AtomStepsModalCustomEvent<any>) => void;
         "onAtomCloseClick"?: (event: AtomStepsModalCustomEvent<any>) => void;
         "onAtomDidDismiss"?: (event: AtomStepsModalCustomEvent<any>) => void;
@@ -1086,22 +1626,50 @@ declare namespace LocalJSX {
         "onAtomNextStep"?: (event: AtomStepsModalCustomEvent<any>) => void;
         "onAtomPreviousStep"?: (event: AtomStepsModalCustomEvent<any>) => void;
         "primaryButtonTextsByStep"?: string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "primary-button-texts-by-step"?: string;
         "secondaryButtonTextsByStep"?: string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "secondary-button-texts-by-step"?: string;
         "steps"?: number;
         "stepsTitles"?: string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "steps-titles"?: string;
         "trigger"?: string;
     }
     interface AtomTag {
         "color"?: 'success' | 'danger' | 'warning' | 'info' | 'dark' | 'light';
         "customBackgroundColor"?: string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "custom-background-color"?: string;
         "customTextColor"?: string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "custom-text-color"?: string;
         "icon"?: IconProps;
     }
     interface AtomTextarea {
         "autoGrow"?: boolean;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "auto-grow"?: boolean;
         "autocomplete"?: 'on' | 'off';
         "autofocus"?: boolean;
         "clearOnEdit"?: boolean;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "clear-on-edit"?: boolean;
         "color"?: 'primary' | 'secondary' | 'danger';
         "cols"?: number;
         "counter"?: boolean;
@@ -1118,10 +1686,32 @@ declare namespace LocalJSX {
     | 'previous'
     | 'search'
     | 'send';
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "enter-key-hint"?: | 'enter'
+    | 'done'
+    | 'go'
+    | 'next'
+    | 'previous'
+    | 'search'
+    | 'send';
         "errorText"?: string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "error-text"?: string;
         "fill"?: 'solid' | 'outline';
         "hasError"?: boolean;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "has-error"?: boolean;
         "helperText"?: string;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "helper-text"?: string;
         "icon"?: IconProps;
         "inputmode"?: | 'none'
     | 'text'
@@ -1133,6 +1723,10 @@ declare namespace LocalJSX {
     | 'search';
         "label"?: string;
         "labelPlacement"?: 'stacked' | 'floating';
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "label-placement"?: 'stacked' | 'floating';
         "maxlength"?: number;
         "minlength"?: number;
         "mode"?: Mode;

--- a/packages/core/src/components/modal/modal.spec.ts
+++ b/packages/core/src/components/modal/modal.spec.ts
@@ -44,6 +44,18 @@ describe('atom-modal', () => {
         </ion-modal>
       </atom-modal>
     `)
+
+    const closeButton = page.root?.querySelector('.atom-modal__close')
+    const primaryButton = page.root?.querySelector(
+      '.atom-modal__btn-action--primary'
+    )
+    const secondaryButton = page.root?.querySelector(
+      '.atom-modal__btn-action--secondary'
+    )
+
+    expect(closeButton?.getAttribute('data-testid')).toBeNull()
+    expect(primaryButton?.getAttribute('data-testid')).toBeNull()
+    expect(secondaryButton?.getAttribute('data-testid')).toBeNull()
   })
 
   it('should render header slot when headerTitle is not passed', async () => {
@@ -244,5 +256,44 @@ describe('atom-modal', () => {
     expect(
       page.root?.querySelector('.atom-modal__btn-action--secondary')
     ).toBeNull()
+  })
+
+  it('should apply data-testid attributes from metaData prop', async () => {
+    const meta = await newSpecPage({
+      components: [AtomModal],
+      html: `
+        <atom-modal
+          trigger="button"
+          primary-button-text="Primary"
+          secondary-button-text="Secondary"
+          disable-primary-button="true""
+        >
+          Modal content
+        </atom-modal>
+        `,
+    })
+
+    // on core mode, we should provide inner props programmatically, otherwise they will not be provider to children component
+    const modal = meta.body.querySelector('atom-modal') as Element & AtomModal
+
+    modal.metaData = {
+      primaryButtonTestId: 'primary-btn',
+      secondaryButtonTestId: 'secondary-btn',
+      closeButtonTestId: 'close-btn',
+    }
+
+    await page.waitForChanges()
+
+    const closeButton = meta.root?.querySelector('.atom-modal__close')
+    const primaryButton = meta.root?.querySelector(
+      '.atom-modal__btn-action--primary'
+    )
+    const secondaryButton = meta.root?.querySelector(
+      '.atom-modal__btn-action--secondary'
+    )
+
+    expect(closeButton?.getAttribute('data-testid')).toBe('close-btn')
+    expect(primaryButton?.getAttribute('data-testid')).toBe('primary-btn')
+    expect(secondaryButton?.getAttribute('data-testid')).toBe('secondary-btn')
   })
 })

--- a/packages/core/src/components/modal/modal.tsx
+++ b/packages/core/src/components/modal/modal.tsx
@@ -11,6 +11,11 @@ import {
 import { IconProps } from '../../icons'
 
 type AlertType = Record<'alert' | 'error', { icon: IconProps; color: string }>
+type MetaData = {
+  primaryButtonTestId?: string
+  secondaryButtonTestId?: string
+  closeButtonTestId?: string
+}
 
 @Component({
   tag: 'atom-modal',
@@ -31,6 +36,7 @@ export class AtomModal {
   @Prop() disableSecondaryButton = false
   @Prop({ mutable: true }) isOpen = false
   @Prop({ mutable: true }) canDismiss?: boolean
+  @Prop() metaData?: MetaData = {}
 
   @Event() atomCloseClick: EventEmitter
   @Event() atomDidDismiss: EventEmitter
@@ -126,6 +132,7 @@ export class AtomModal {
               onClick={this.handleCloseClick}
               aria-label='close'
               class='atom-modal__close'
+              data-testid={this.metaData.closeButtonTestId}
             >
               <atom-icon
                 icon='close'
@@ -156,6 +163,7 @@ export class AtomModal {
                   fill='outline'
                   class='atom-modal__btn-action atom-modal__btn-action--secondary'
                   onClick={this.handleSecondaryClick}
+                  data-testid={this.metaData.secondaryButtonTestId}
                 >
                   {this.secondaryButtonText}
                 </atom-button>
@@ -165,6 +173,7 @@ export class AtomModal {
                 disabled={this.disablePrimaryButton}
                 class='atom-modal__btn-action atom-modal__btn-action--primary'
                 onClick={this.handlePrimaryClick}
+                data-testid={this.metaData.primaryButtonTestId}
               >
                 {this.primaryButtonText}
               </atom-button>

--- a/packages/core/src/components/modal/stories/modal.args.ts
+++ b/packages/core/src/components/modal/stories/modal.args.ts
@@ -1,5 +1,4 @@
 import { Category } from '@atomium/storybook-utils/enums/table'
-import DocumentationTemplate from '@atomium/storybook-utils/templates/DocumentationWithoutStories.mdx'
 import { withActions } from '@storybook/addon-actions/decorator'
 
 export const ModalStoryArgs = {
@@ -18,7 +17,6 @@ export const ModalStoryArgs = {
         component:
           'Wrapper of Ionic Modal component. Read the [Ionic documentation](https://ionicframework.com/docs/api/modal) for more information about the available properties and possibilities.',
       },
-      page: DocumentationTemplate,
     },
   },
   decorators: [withActions],
@@ -230,6 +228,14 @@ export const ModalStoryArgs = {
       description: 'Method to close the modal after it has been presented.',
       table: {
         category: Category.METHODS,
+      },
+    },
+    metaData: {
+      control: 'object',
+      description:
+        'Object containing data-testid for modal actions such as primary and secondary buttons. Example: `{ primaryButtonTestId: "primary-btn", secondaryButtonTestId: "secondary-btn", closeButtonTestId: "close-btn" }`',
+      table: {
+        category: Category.PROPERTIES,
       },
     },
   },

--- a/packages/core/src/components/modal/stories/modal.core.stories.tsx
+++ b/packages/core/src/components/modal/stories/modal.core.stories.tsx
@@ -11,21 +11,21 @@ export default {
 const createModal = (args) => {
   return html`
     <div>
-      <atom-button id="open-modal">Open Modal</atom-button>
+      <atom-button id="${args.trigger}">open modal</atom-button>
       <atom-modal
         alert-type="${args.alertType}"
         has-divider="${args.hasDivider}"
         primary-button-text="${args.primaryButtonText}"
         secondary-button-text="${args.secondaryButtonText}"
-        trigger="open-modal"
+        trigger=${args.trigger}
         progress="${args.progress}"
         has-footer="${args.hasFooter}"
         header-title="${args.headerTitle}"
         disable-secondary-button="${args.disableSecondaryButton}"
         disable-primary-button="${args.disablePrimaryButton}"
         is-open="${args.isOpen}"
-        can-dismiss="${args.canDismiss}"
         id="${args.id}"
+        can-dismiss="${args.canDismiss}"
       >
         <div slot="header">Custom Header</div>
         <p>Modal Content</p>
@@ -34,7 +34,13 @@ const createModal = (args) => {
 
      <script>
      ;(function () {
-      document.querySelector('atom-modal').metaData = ${JSON.stringify(args.metaData || {})}
+      // for automated test section
+      const modal = document.querySelector('#automated-test-modal')
+
+      if(modal) {
+        modal.metaData = ${JSON.stringify(args.metaData || {})}
+      }
+
       })()
       </script>
   `
@@ -44,6 +50,7 @@ export const Default: StoryObj = {
   render: (args) => createModal(args),
   args: {
     ...ModalComponentArgs,
+    trigger: 'open-modal',
   },
 }
 
@@ -52,6 +59,7 @@ export const Divided: StoryObj = {
   args: {
     ...ModalComponentArgs,
     hasDivider: true,
+    trigger: 'open-modal-1',
   },
 }
 
@@ -60,6 +68,7 @@ export const Progress: StoryObj = {
   args: {
     ...ModalComponentArgs,
     progress: 0.5,
+    trigger: 'open-modal-2',
   },
 }
 
@@ -68,6 +77,7 @@ export const Alert: StoryObj = {
   args: {
     ...ModalComponentArgs,
     alertType: 'alert',
+    trigger: 'open-modal-3',
   },
 }
 
@@ -76,6 +86,7 @@ export const ErrorModal: StoryObj = {
   args: {
     ...ModalComponentArgs,
     alertType: 'error',
+    trigger: 'open-modal-4',
   },
 }
 
@@ -84,6 +95,7 @@ export const HeaderTitle: StoryObj = {
   args: {
     ...ModalComponentArgs,
     headerTitle: 'Title',
+    trigger: 'open-modal-5',
   },
 }
 
@@ -96,5 +108,7 @@ export const AutomatedTest: StoryObj = {
       secondaryButtonTestId: 'secondary-btn',
       closeButtonTestId: 'close-btn',
     },
+    trigger: 'open-modal-6',
+    id: 'automated-test-modal',
   },
 }

--- a/packages/core/src/components/modal/stories/modal.core.stories.tsx
+++ b/packages/core/src/components/modal/stories/modal.core.stories.tsx
@@ -31,6 +31,12 @@ const createModal = (args) => {
         <p>Modal Content</p>
       </<atom-modal>
     </div>
+
+     <script>
+     ;(function () {
+      document.querySelector('atom-modal').metaData = ${JSON.stringify(args.metaData || {})}
+      })()
+      </script>
   `
 }
 
@@ -78,5 +84,17 @@ export const HeaderTitle: StoryObj = {
   args: {
     ...ModalComponentArgs,
     headerTitle: 'Title',
+  },
+}
+
+export const AutomatedTest: StoryObj = {
+  render: (args) => createModal(args),
+  args: {
+    ...ModalComponentArgs,
+    metaData: {
+      primaryButtonTestId: 'primary-btn',
+      secondaryButtonTestId: 'secondary-btn',
+      closeButtonTestId: 'close-btn',
+    },
   },
 }

--- a/packages/core/src/components/modal/stories/modal.react.stories.tsx
+++ b/packages/core/src/components/modal/stories/modal.react.stories.tsx
@@ -25,6 +25,7 @@ const createModal = (args) => (
       isOpen={args.isOpen}
       canDismiss={args.canDismiss}
       id={args.id}
+      metaData={args.metaData || {}}
     >
       <div slot='header'>Custom Header</div>
       <p>Modal Content</p>
@@ -76,5 +77,17 @@ export const HeaderTitle: StoryObj = {
   args: {
     ...ModalComponentArgs,
     headerTitle: 'Title',
+  },
+}
+
+export const AutomatedTest: StoryObj = {
+  render: (args) => createModal(args),
+  args: {
+    ...ModalComponentArgs,
+    metaData: {
+      primaryButtonTestId: 'primary-btn',
+      secondaryButtonTestId: 'secondary-btn',
+      closeButtonTestId: 'close-btn',
+    },
   },
 }

--- a/packages/core/src/components/modal/stories/modal.react.stories.tsx
+++ b/packages/core/src/components/modal/stories/modal.react.stories.tsx
@@ -12,13 +12,13 @@ export default {
 
 const createModal = (args) => (
   <div>
-    <AtomButton id='open-modal'>Open Modal</AtomButton>
+    <AtomButton id={args.trigger}>Open Modal</AtomButton>
     <AtomModal
       alertType={args.alertType}
       hasDivider={args.hasDivider}
       primaryButtonText={args.primaryButtonText}
       secondaryButtonText={args.secondaryButtonText}
-      trigger='open-modal'
+      trigger={args.trigger}
       progress={args.progress}
       disablePrimaryButton={args.disablePrimaryButton}
       disableSecondaryButton={args.disableSecondaryButton}
@@ -37,6 +37,7 @@ export const Default: StoryObj = {
   render: (args) => createModal(args),
   args: {
     ...ModalComponentArgs,
+    trigger: 'open-modal',
   },
 }
 
@@ -45,6 +46,7 @@ export const Divided: StoryObj = {
   args: {
     ...ModalComponentArgs,
     hasDivider: true,
+    trigger: 'open-modal-2',
   },
 }
 
@@ -53,6 +55,7 @@ export const Progress: StoryObj = {
   args: {
     ...ModalComponentArgs,
     progress: 0.5,
+    trigger: 'open-modal-3',
   },
 }
 
@@ -61,6 +64,7 @@ export const Alert: StoryObj = {
   args: {
     ...ModalComponentArgs,
     alertType: 'alert',
+    trigger: 'open-modal-4',
   },
 }
 
@@ -69,6 +73,7 @@ export const ErrorModal: StoryObj = {
   args: {
     ...ModalComponentArgs,
     alertType: 'error',
+    trigger: 'open-modal-5',
   },
 }
 
@@ -77,6 +82,7 @@ export const HeaderTitle: StoryObj = {
   args: {
     ...ModalComponentArgs,
     headerTitle: 'Title',
+    trigger: 'open-modal-6',
   },
 }
 
@@ -89,5 +95,6 @@ export const AutomatedTest: StoryObj = {
       secondaryButtonTestId: 'secondary-btn',
       closeButtonTestId: 'close-btn',
     },
+    trigger: 'open-modal-7',
   },
 }

--- a/packages/core/src/components/modal/stories/modal.vue.stories.tsx
+++ b/packages/core/src/components/modal/stories/modal.vue.stories.tsx
@@ -107,7 +107,7 @@ export const ReactivityProblemOnEmit: StoryObj = {
       <AtomButton id='open-modal' @click="isOpen=true">Open the modal to see the example code</AtomButton> or <AtomButton
       fill="clear"
       type="button"
-      href="https://github.com/juntossomosmais/atomium"
+      href="https://github.com/juntossomosmais/atomium/blob/9acac8688128569e033598c2a5f3267746837385/packages/core/src/components/modal/stories/modal.vue.stories.tsx#L145-L166"
       >see the example on GitHub</AtomButton>
       <AtomModal
         disable-primary-button="${ModalComponentArgs.disablePrimaryButton}"

--- a/packages/core/src/components/modal/stories/modal.vue.stories.tsx
+++ b/packages/core/src/components/modal/stories/modal.vue.stories.tsx
@@ -28,6 +28,7 @@ const createModal = (args, themeColor = 'light') => ({
         is-open="${args.isOpen}"
         can-dismiss="${args.canDismiss}"
         id="${args.id}"
+        meta-data="${args.metaData}"
       >
         <div slot='header'>Custom Header</div>
         <p>Modal Content</p>
@@ -80,5 +81,98 @@ export const HeaderTitle: StoryObj = {
   args: {
     ...ModalComponentArgs,
     headerTitle: 'Title',
+  },
+}
+
+export const AutomatedTest: StoryObj = {
+  render: (args) => createModal(args),
+  args: {
+    ...ModalComponentArgs,
+    metaData: {
+      primaryButtonTestId: 'primary-btn',
+      secondaryButtonTestId: 'secondary-btn',
+      closeButtonTestId: 'close-btn',
+    },
+  },
+}
+
+export const ReactivityProblemOnEmit: StoryObj = {
+  render: () => ({
+    components: { AtomModal, AtomButton },
+    setup() {
+      return { ModalComponentArgs, themeColor: 'light' }
+    },
+    template: `
+    <div>
+      <AtomButton id='open-modal' @click="isOpen=true">Open the modal to see the example code</AtomButton> or <AtomButton
+      fill="clear"
+      type="button"
+      href="https://github.com/juntossomosmais/atomium"
+      >see the example on GitHub</AtomButton>
+      <AtomModal
+        disable-primary-button="${ModalComponentArgs.disablePrimaryButton}"
+        disable-secondary-button="${ModalComponentArgs.disableSecondaryButton}"
+        :is-open="isOpen"
+        @atom-primary-click="handleClose"
+      >
+        <div slot='header'>Example to avoid problem on emit event and close modal immediately</div>
+
+     <pre><code class="language-javascript">
+      data() {
+        return {
+          isOpen: false,
+        }
+      },
+      methods: {
+        handleClose() {
+          // Ensure the modal is closed
+          // before emitting the action
+          this.isOpen = false
+          this.$nextTick(() => {
+            // Then emit the action
+            this.$emit('emit-once-the-modal-is-closed')
+          })
+
+          // Avoid doing this:
+          this.isOpen = false
+          this.$emit('emit-but-the-modal-is-still-open')
+        },
+      }
+    </code></pre>
+      </AtomModal>
+    </div>
+  `,
+    data() {
+      return {
+        isOpen: false,
+        other: false,
+      }
+    },
+    methods: {
+      handleClose() {
+        // do
+        this.isOpen = false
+        this.$nextTick(() => {
+          // then emit action
+          this.$emit('emit-action-to-dad-component')
+        })
+
+        /* don't do this:
+         * this.isOpen = false
+         * this.$emit('emit-action-to-dad-component') // emit action
+         */
+      },
+    },
+  }),
+  args: {
+    ...ModalComponentArgs,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`AtomModal` does not handle Vue emits ($emit) well when they are executed immediately after the modal is closed. This behavior seems to be related to the teleport mechanism used internally. <br/> <br/> In such cases, if the `isOpen` flag is changed to false and a event is emitted, the dad component receives the emit properly, but the modal remains open even though its parent component no longer exists. For this case, use `$nextTick` to ensure that the modal is closed before executing the action. ',
+      },
+    },
   },
 }

--- a/packages/core/src/components/modal/stories/modal.vue.stories.tsx
+++ b/packages/core/src/components/modal/stories/modal.vue.stories.tsx
@@ -15,13 +15,13 @@ const createModal = (args, themeColor = 'light') => ({
   },
   template: `
     <div>
-      <AtomButton id='open-modal'>Open Modal</AtomButton>
+      <AtomButton id='${args.trigger}'>Open Modal</AtomButton>
       <AtomModal
         alert-type="${args.alertType}"
         has-divider="${args.hasDivider}"
         primary-button-text="${args.primaryButtonText}"
         secondary-button-text="${args.secondaryButtonText}"
-        trigger="open-modal"
+        trigger="${args.trigger}"
         progress="${args.progress}"
         disable-primary-button="${args.disablePrimaryButton}"
         disable-secondary-button="${args.disableSecondaryButton}"
@@ -41,6 +41,7 @@ export const Default: StoryObj = {
   render: (args) => createModal(args),
   args: {
     ...ModalComponentArgs,
+    trigger: 'open-modal',
   },
 }
 
@@ -49,6 +50,7 @@ export const Divided: StoryObj = {
   args: {
     ...ModalComponentArgs,
     hasDivider: true,
+    trigger: 'open-modal-2',
   },
 }
 
@@ -57,6 +59,7 @@ export const Progress: StoryObj = {
   args: {
     ...ModalComponentArgs,
     progress: 0.5,
+    trigger: 'open-modal-3',
   },
 }
 
@@ -65,6 +68,7 @@ export const Alert: StoryObj = {
   args: {
     ...ModalComponentArgs,
     alertType: 'alert',
+    trigger: 'open-modal-4',
   },
 }
 
@@ -73,6 +77,7 @@ export const ErrorModal: StoryObj = {
   args: {
     ...ModalComponentArgs,
     alertType: 'error',
+    trigger: 'open-modal-5',
   },
 }
 
@@ -81,6 +86,7 @@ export const HeaderTitle: StoryObj = {
   args: {
     ...ModalComponentArgs,
     headerTitle: 'Title',
+    trigger: 'open-modal-6',
   },
 }
 
@@ -93,6 +99,7 @@ export const AutomatedTest: StoryObj = {
       secondaryButtonTestId: 'secondary-btn',
       closeButtonTestId: 'close-btn',
     },
+    trigger: 'open-modal-7',
   },
 }
 
@@ -104,7 +111,7 @@ export const ReactivityProblemOnEmit: StoryObj = {
     },
     template: `
     <div>
-      <AtomButton id='open-modal' @click="isOpen=true">Open the modal to see the example code</AtomButton> or <AtomButton
+      <AtomButton  @click="isOpen=true">Open the modal to see the example code</AtomButton> or <AtomButton
       fill="clear"
       type="button"
       href="https://github.com/juntossomosmais/atomium/blob/9acac8688128569e033598c2a5f3267746837385/packages/core/src/components/modal/stories/modal.vue.stories.tsx#L145-L166"


### PR DESCRIPTION
[Task](https://juntossomosmais.monday.com/boards/3328436962/views/97222821/pulses/8785771495)

## Summary

This pull request introduces a new `metaData` prop to the `AtomModal` component, allowing for better testing by setting `data-testid` attributes on modal action buttons. Additionally, it updates storybook stories to include this new prop and adds a new story for automated testing.

### New Feature: `metaData` Prop

* [`packages/core/src/components/modal/modal.tsx`](diffhunk://#diff-7fb4c73444f6323ac7310269fc6ccc9463cb97edd3cd3e634c88916598732ccdR14-R18): Added a new `metaData` prop to the `AtomModal` component to allow setting `data-testid` attributes on the primary, secondary, and close buttons.

## Evidences

![Captura de Tela 2025-03-28 às 08 28 27](https://github.com/user-attachments/assets/5d7f42d6-3abd-43fa-9eeb-4dc75fc2cb3a)
