### PR TITLE
feat(datetime): add date-target and time-target slots

### DIFF
--- a/packages/core/src/components/datetime/datetime.spec.ts
+++ b/packages/core/src/components/datetime/datetime.spec.ts
@@ -162,4 +162,24 @@ describe('AtomDatetime', () => {
 
     expect(spy).toHaveBeenCalled()
   })
+
+  it('should render custom dateTarget when dateTarget slot is used', async () => {
+    const page = await newSpecPage({
+      components: [AtomDatetime],
+      html: `<atom-datetime>
+        <div slot="date-target">Custom Date Target</div>
+      </atom-datetime>`,
+    })
+
+    await page.waitForChanges()
+
+    expect(page.root).toEqualHtml(`
+      <atom-datetime>
+        <div slot="date-target">
+          Custom Date Target
+        </div>
+        <ion-datetime class="atom-datetime" color="secondary" hourcycle="h23" id="datetime" locale="pt-BR" mode="md" presentation="date" size="fixed"></ion-datetime>
+      </atom-datetime>
+    `)
+  })
 })

--- a/packages/core/src/components/datetime/datetime.tsx
+++ b/packages/core/src/components/datetime/datetime.tsx
@@ -219,7 +219,10 @@ export class AtomDatetime {
                 datetime={this.datetimeId}
                 disabled={this.disabled}
                 mode='md'
-              ></ion-datetime-button>
+              >
+                <slot name='date-target' />
+                <slot name='time-target' />
+              </ion-datetime-button>
               <span class='atom-label'>{this.label}</span>
               <atom-icon
                 class='atom-icon'

--- a/packages/core/src/components/datetime/stories/datetime.args.ts
+++ b/packages/core/src/components/datetime/stories/datetime.args.ts
@@ -186,6 +186,22 @@ export const DatetimeStoryArgs = {
         category: Category.SLOTS,
       },
     },
+    dateTarget: {
+      control: 'text',
+      description:
+        'The date value displayed when used with useButton. If not provided, the default date format will be shown.',
+      table: {
+        category: Category.SLOTS,
+      },
+    },
+    timeTarget: {
+      control: 'text',
+      description:
+        'The time value displayed when used with useButton. If not provided, the default time format will be shown.',
+      table: {
+        category: Category.SLOTS,
+      },
+    },
     useButton: {
       control: 'boolean',
       description: 'If true, the datetime uses a button.',

--- a/packages/core/src/components/datetime/stories/datetime.core.stories.tsx
+++ b/packages/core/src/components/datetime/stories/datetime.core.stories.tsx
@@ -172,7 +172,6 @@ export const UsingWithButton: StoryObj = {
           presentation="date-time"
         >
           <span slot="date-target">Custom Date</span>
-          <span slot="time-target">Custom Time</span>
         </atom-datetime>
       </atom-col>
     </atom-grid>

--- a/packages/core/src/components/datetime/stories/datetime.core.stories.tsx
+++ b/packages/core/src/components/datetime/stories/datetime.core.stories.tsx
@@ -169,7 +169,7 @@ export const UsingWithButton: StoryObj = {
           use-button="true"
           label="Selecione uma data"
           datetime-id="datetime-with-custom-date-format"
-          presentation="date"
+          presentation="date-time"
         >
           <span slot="date-target">Custom Date</span>
           <span slot="time-target">Custom Time</span>

--- a/packages/core/src/components/datetime/stories/datetime.core.stories.tsx
+++ b/packages/core/src/components/datetime/stories/datetime.core.stories.tsx
@@ -169,7 +169,7 @@ export const UsingWithButton: StoryObj = {
           use-button="true"
           label="Selecione uma data"
           datetime-id="datetime-with-custom-date-format"
-          presentation="date-time"
+          presentation="date"
         >
           <span slot="date-target">Custom Date</span>
         </atom-datetime>

--- a/packages/core/src/components/datetime/stories/datetime.core.stories.tsx
+++ b/packages/core/src/components/datetime/stories/datetime.core.stories.tsx
@@ -164,6 +164,17 @@ export const UsingWithButton: StoryObj = {
           .formatOptions="${{ date: { month: 'long', year: 'numeric' } }}"
         ></atom-datetime>
       </atom-col>
+      <atom-col size="8">
+        <atom-datetime
+          use-button="true"
+          label="Selecione uma data"
+          datetime-id="datetime-with-custom-date-format"
+          presentation="date"
+        >
+          <span slot="date-target">Custom Date</span>
+          <span slot="time-target">Custom Time</span>
+        </atom-datetime>
+      </atom-col>
     </atom-grid>
   `,
 }

--- a/packages/core/src/components/datetime/stories/datetime.react.stories.tsx
+++ b/packages/core/src/components/datetime/stories/datetime.react.stories.tsx
@@ -163,7 +163,7 @@ export const UsingWithButton = {
           useButton={true}
           label='Selecione uma data'
           datetimeId='datetime-with-custom-date-format'
-          presentation='date'
+          presentation='date-time'
         >
           <span slot="date-target">Custom-Date</span>
           <span slot="time-target">Custom Time</span>

--- a/packages/core/src/components/datetime/stories/datetime.react.stories.tsx
+++ b/packages/core/src/components/datetime/stories/datetime.react.stories.tsx
@@ -166,7 +166,6 @@ export const UsingWithButton = {
           presentation='date-time'
         >
           <span slot="date-target">Custom-Date</span>
-          <span slot="time-target">Custom Time</span>
         </AtomDatetime>
       </AtomCol>
     </AtomGrid>

--- a/packages/core/src/components/datetime/stories/datetime.react.stories.tsx
+++ b/packages/core/src/components/datetime/stories/datetime.react.stories.tsx
@@ -163,7 +163,7 @@ export const UsingWithButton = {
           useButton={true}
           label='Selecione uma data'
           datetimeId='datetime-with-custom-date-format'
-          presentation='date-time'
+          presentation='date'
         >
           <span slot="date-target">Custom-Date</span>
         </AtomDatetime>

--- a/packages/core/src/components/datetime/stories/datetime.react.stories.tsx
+++ b/packages/core/src/components/datetime/stories/datetime.react.stories.tsx
@@ -158,6 +158,17 @@ export const UsingWithButton = {
           formatOptions={{ date: { month: 'long', year: 'numeric' } }}
         />
       </AtomCol>
+      <AtomCol size='8'>
+        <AtomDatetime
+          useButton={true}
+          label='Selecione uma data'
+          datetimeId='datetime-with-custom-date-format'
+          presentation='date'
+        >
+          <span slot="date-target">Custom-Date</span>
+          <span slot="time-target">Custom Time</span>
+        </AtomDatetime>
+      </AtomCol>
     </AtomGrid>
   ),
 }

--- a/packages/core/src/components/datetime/stories/datetime.vue.stories.tsx
+++ b/packages/core/src/components/datetime/stories/datetime.vue.stories.tsx
@@ -212,7 +212,7 @@ export const UsingWithButton = {
             useButton="true"
             label="Selecione uma data"
             datetimeId="datetime-with-button-date"
-            presentation="date-time"
+            presentation="date"
           >
             <span slot="date-target">Custom Date</span>
           </AtomDatetime>

--- a/packages/core/src/components/datetime/stories/datetime.vue.stories.tsx
+++ b/packages/core/src/components/datetime/stories/datetime.vue.stories.tsx
@@ -212,7 +212,7 @@ export const UsingWithButton = {
             useButton="true"
             label="Selecione uma data"
             datetimeId="datetime-with-button-date"
-            presentation="date"
+            presentation="date-time"
           >
             <span slot="date-target">Custom Date</span>
             <span slot="time-target">Custom Time</span>

--- a/packages/core/src/components/datetime/stories/datetime.vue.stories.tsx
+++ b/packages/core/src/components/datetime/stories/datetime.vue.stories.tsx
@@ -207,6 +207,17 @@ export const UsingWithButton = {
             formatOptions="${{ date: { month: 'long', year: 'numeric' } }}"
           />
         </AtomCol>
+        <AtomCol size="8">
+          <AtomDatetime
+            useButton="true"
+            label="Selecione uma data"
+            datetimeId="datetime-with-button-date"
+            presentation="date"
+          >
+            <span slot="date-target">Custom Date</span>
+            <span slot="time-target">Custom Time</span>
+          </AtomDatetime>
+        </AtomCol>
       </AtomGrid>
     `,
   }),

--- a/packages/core/src/components/datetime/stories/datetime.vue.stories.tsx
+++ b/packages/core/src/components/datetime/stories/datetime.vue.stories.tsx
@@ -215,7 +215,6 @@ export const UsingWithButton = {
             presentation="date-time"
           >
             <span slot="date-target">Custom Date</span>
-            <span slot="time-target">Custom Time</span>
           </AtomDatetime>
         </AtomCol>
       </AtomGrid>


### PR DESCRIPTION
[Task](https://juntossomosmais.monday.com/boards/5143488854/pulses/9210434084)

## Summary

This pull request enhances the `AtomDatetime` component by adding support for custom date and time target slots, improving its flexibility and customization options. The changes include updates to the component's functionality, tests, and storybook documentation.

### Enhancements to `AtomDatetime` functionality:
* Updated `AtomDatetime` to support `date-target` and `time-target` slots, allowing users to customize the displayed date and time values when using the datetime button. (`packages/core/src/components/datetime/datetime.tsx`)

## Evidences

![image](https://github.com/user-attachments/assets/d65a3be2-c650-47b7-ad34-46c43ac5128e)
