### PR TITLE
fix(core): include core css on exports

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -56,6 +56,10 @@
     "./vue": {
       "types": "./vue/dist/types/index.d.ts",
       "import": "./vue/dist/esm/index.js"
+    },
+    "./core.css": {
+      "import": "./core.css",
+      "require": "./core.css"
     }
   },
   "nx": {


### PR DESCRIPTION
[Task](https://juntossomosmais.monday.com/boards/5143488854/views/113762127/pulses/9286490020)

## Summary

After add explicit exports, that will be needed after stencil upgrade, core.css is not found for imports.

## Evidences

Media(images, gifs or videos) that shows the result of your work.
