### PR TITLE
fix(tooltip): use popper instance to get correct placement

### DIFF
--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -657,7 +657,11 @@ export namespace Components {
     | 'bottom-start'
     | 'bottom-end'
     | 'right'
-    | 'left';
+    | 'right-start'
+    | 'right-end'
+    | 'left'
+    | 'left-start'
+    | 'left-end';
     }
 }
 export interface AtomAlertCustomEvent<T> extends CustomEvent<T> {
@@ -1782,7 +1786,11 @@ declare namespace LocalJSX {
     | 'bottom-start'
     | 'bottom-end'
     | 'right'
-    | 'left';
+    | 'right-start'
+    | 'right-end'
+    | 'left'
+    | 'left-start'
+    | 'left-end';
     }
     interface IntrinsicElements {
         "atom-alert": AtomAlert;

--- a/packages/core/src/components/tooltip/stories/tooltip.args.ts
+++ b/packages/core/src/components/tooltip/stories/tooltip.args.ts
@@ -30,7 +30,11 @@ export const TooltipStoryArgs = {
         'bottom-start',
         'bottom-end',
         'right',
+        'right-start',
+        'right-end',
         'left',
+        'left-start',
+        'left-end',
       ],
       description: 'Determines placement for tooltip',
       table: {

--- a/packages/core/src/components/tooltip/tooltip.spec.ts
+++ b/packages/core/src/components/tooltip/tooltip.spec.ts
@@ -25,7 +25,7 @@ describe('AtomTooltip', () => {
       expect(page.root).toEqualHtml(`
         <atom-tooltip action="hover" data-popper-placement="top" data-popper-reference-hidden element="hover" id="hover--tooltip" open="false" part="tooltip" role="tooltip" style="z-index: -1; position: absolute; left: 0; top: auto; margin: 0; right: auto; bottom: 0; transform: translate(0px, 0px);">
           <mock:shadow-root>
-            <div class="atom-tooltip" data-hide data-placement="top" part="tooltip">
+            <div class="atom-tooltip" data-hide data-placement="bottom" part="tooltip">
               <div class="atom-tooltip__content">
                 <slot></slot>
               </div>

--- a/packages/core/src/components/tooltip/tooltip.tsx
+++ b/packages/core/src/components/tooltip/tooltip.tsx
@@ -44,7 +44,11 @@ export class AtomTooltip {
     | 'bottom-start'
     | 'bottom-end'
     | 'right'
-    | 'left' = 'top'
+    | 'right-start'
+    | 'right-end'
+    | 'left'
+    | 'left-start'
+    | 'left-end' = 'top'
 
   @Watch('placement')
   placementShouldUpdatePopperInstance(newPlacement: typeof this.placement) {
@@ -52,6 +56,7 @@ export class AtomTooltip {
       ...options,
       placement: newPlacement,
     }))
+
     this._popperInstance.update()
   }
 
@@ -228,7 +233,7 @@ export class AtomTooltip {
         role={isMobile() ? 'dialog' : 'tooltip'}
       >
         <div
-          data-placement={this.placement}
+          data-placement={this._popperInstance.state.placement}
           data-hide={!this.open}
           data-show={this.open}
           class={{ 'atom-tooltip': true }}


### PR DESCRIPTION
[Task](https://juntossomosmais.monday.com/boards/5143488854/views/113762127/pulses/9318826260)

Closes: https://github.com/juntossomosmais/atomium/issues/707

## Summary

This pull request enhances the `AtomTooltip` component by adding new tooltip placement options and improving the handling of tooltip placement updates. The most important changes include extending the list of valid placements, updating the default placement behavior, and ensuring the tooltip's rendered placement dynamically reflects the Popper.js state.

### Enhancements to tooltip placement:

* [`packages/core/src/components/tooltip/stories/tooltip.args.ts`](diffhunk://#diff-0a6210d13824b7f9eb6a6bd02a924bf5cdbcacb7cb6a7ddb73046127e251bfa2R33-R37): Added new placement options (`right-start`, `right-end`, `left-start`, `left-end`) to the `TooltipStoryArgs` configuration, allowing more precise tooltip positioning.

* [`packages/core/src/components/tooltip/tooltip.tsx`](diffhunk://#diff-36a0a111f74d27f0520e694610ca082cea8442fe714a28b053ec6d827049dc12L47-R59): Extended the `placement` property to include the new options (`right-start`, `right-end`, `left-start`, `left-end`) and updated the default placement to `top`.

### Dynamic placement handling:

* [`packages/core/src/components/tooltip/tooltip.tsx`](diffhunk://#diff-36a0a111f74d27f0520e694610ca082cea8442fe714a28b053ec6d827049dc12L231-R236): Updated the `data-placement` attribute to dynamically reflect the current placement state from the Popper.js instance, ensuring accurate representation of the tooltip's rendered position.

## Evidences

Before

https://github.com/user-attachments/assets/559a474c-b10e-401f-a93a-819bef010986

After

https://github.com/user-attachments/assets/fa31345d-20ce-46b9-9661-289da6a19e04



