### PR TITLE
feat(meter): use regular color on meter component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23858,7 +23858,7 @@
     },
     "packages/core": {
       "name": "@juntossomosmais/atomium",
-      "version": "3.12.3"
+      "version": "3.14.1"
     },
     "packages/icons": {
       "name": "@juntossomosmais/atomium-icons"

--- a/packages/core/src/components/meter/meter.scss
+++ b/packages/core/src/components/meter/meter.scss
@@ -65,7 +65,7 @@
     width: 0;
 
     &.is-success {
-      background-color: var(--color-contextual-success-light-1);
+      background-color: var(--color-contextual-success-regular);
     }
 
     &.is-warning {


### PR DESCRIPTION
[Task](https://juntossomosmais.monday.com/boards/1757192123/pulses/9760558666)

## Summary

This pull request makes a minor update to the `meter.scss` file, adjusting the color used for the success state of the meter component to improve visual consistency. 

* Changed the `background-color` for the `.is-success` class from `--color-contextual-success-light-1` to `--color-contextual-success-regular` in `meter.scss`.

## Evidences

<img width="758" height="363" alt="Captura de Tela 2025-08-06 às 16 09 18" src="https://github.com/user-attachments/assets/2570b642-7806-467e-b2cc-9f16c64be7d3" />
