### PR TITLE
feat(tooltip): add fixed prop to keep tooltip persistently open

### DIFF
--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -641,6 +641,10 @@ export namespace Components {
         /**
           * @default false
          */
+        "fixed": boolean;
+        /**
+          * @default false
+         */
         "open": boolean;
         /**
           * @default 'top'
@@ -1759,6 +1763,10 @@ declare namespace LocalJSX {
         "action"?: 'hover' | 'click';
         "element"?: string;
         /**
+          * @default false
+         */
+        "fixed"?: boolean;
+        /**
           * Event is dispatched when: 1. Mouse leave event in selector 2. Click "Close" button when is mobile
          */
         "onAtomClose"?: (event: AtomTooltipCustomEvent<any>) => void;
@@ -2105,6 +2113,7 @@ declare namespace LocalJSX {
     | 'left-start'
     | 'left-end';
         "action": 'hover' | 'click';
+        "fixed": boolean;
     }
 
     interface IntrinsicElements {

--- a/packages/core/src/components/tooltip/stories/tooltip.args.ts
+++ b/packages/core/src/components/tooltip/stories/tooltip.args.ts
@@ -66,6 +66,15 @@ export const TooltipStoryArgs = {
         category: Category.PROPERTIES,
       },
     },
+    fixed: {
+      control: 'boolean',
+      defaultValue: { summary: false },
+      description:
+        'Keeps the tooltip open until the close button is clicked. Ignores all auto-close triggers.',
+      table: {
+        category: Category.PROPERTIES,
+      },
+    },
     text: {
       control: 'text',
       description: 'Determines a text for tooltip.',
@@ -101,4 +110,5 @@ export const TooltipComponentArgs = {
   text: 'Tooltip',
   action: 'hover',
   open: false,
+  fixed: false,
 }

--- a/packages/core/src/components/tooltip/stories/tooltip.core.stories.tsx
+++ b/packages/core/src/components/tooltip/stories/tooltip.core.stories.tsx
@@ -20,6 +20,7 @@ const createTooltip = (args, buttonText = 'hover') => {
       element="${args.element}"
       action="${args.action}"
       open="${args.open}"
+      fixed="${args.fixed}"
     >
       ${args.text}
     </atom-tooltip>
@@ -60,6 +61,17 @@ export const Opened: StoryObj = {
     element: 'opened',
     placement: 'left',
     action: 'click',
+    open: true,
+  },
+}
+
+export const Fixed: StoryObj = {
+  render: (args) => createTooltip(args, 'Fixed'),
+  args: {
+    ...TooltipComponentArgs,
+    element: 'fixed',
+    placement: 'top',
+    fixed: true,
     open: true,
   },
 }

--- a/packages/core/src/components/tooltip/stories/tooltip.react.stories.tsx
+++ b/packages/core/src/components/tooltip/stories/tooltip.react.stories.tsx
@@ -26,6 +26,7 @@ const createTooltip = (args, buttonText = 'Hover') => (
       element={args.element}
       action={args.action}
       open={args.open}
+      fixed={args.fixed}
     >
       <div>{args.text}</div>
     </AtomTooltip>
@@ -57,6 +58,17 @@ export const Opened: StoryObj = {
     element: 'opened',
     placement: 'left',
     action: 'click',
+    open: true,
+  },
+}
+
+export const Fixed: StoryObj = {
+  render: (args) => createTooltip(args, 'Fixed'),
+  args: {
+    ...TooltipComponentArgs,
+    element: 'fixed',
+    placement: 'top',
+    fixed: true,
     open: true,
   },
 }

--- a/packages/core/src/components/tooltip/stories/tooltip.vue.stories.tsx
+++ b/packages/core/src/components/tooltip/stories/tooltip.vue.stories.tsx
@@ -29,6 +29,7 @@ const createTooltip = (args, buttonText = 'Hover') => ({
       element="${args.element}"
       action="${args.action}"
       open="${args.open}"
+      fixed="${args.fixed}"
     >
       <div>${args.text}</div>
     </AtomTooltip>
@@ -60,6 +61,17 @@ export const Opened: StoryObj = {
     element: 'opened',
     placement: 'left',
     action: 'click',
+    open: true,
+  },
+}
+
+export const Fixed: StoryObj = {
+  render: (args) => createTooltip(args, 'Fixed'),
+  args: {
+    ...TooltipComponentArgs,
+    element: 'fixed',
+    placement: 'top',
+    fixed: true,
     open: true,
   },
 }

--- a/packages/core/src/components/tooltip/tooltip.scss
+++ b/packages/core/src/components/tooltip/tooltip.scss
@@ -20,7 +20,7 @@ $placements: 'top', 'bottom', 'left', 'right';
 
     background: var(--background, var(--color-neutral-light-1));
     border-radius: var(--border-radius);
-    color: var(--color-neutral-white);
+    color: var(--color, var(--color-neutral-white));
     font: var(--text-body-small);
     letter-spacing: var(--text-body-small-letter);
     padding: var(--spacing-xsmall);

--- a/packages/core/src/components/tooltip/tooltip.spec.ts
+++ b/packages/core/src/components/tooltip/tooltip.spec.ts
@@ -194,4 +194,62 @@ describe('AtomTooltip', () => {
         ?.shadowRoot?.querySelector('.atom-tooltip')
     ).toHaveAttribute('data-show')
   })
+
+  describe('fixed prop', () => {
+    const fixedTooltip = `
+      <button id="fixed" aria-describedby="fixed--tooltip">Trigger</button>
+      <atom-tooltip id="fixed--tooltip" element="fixed" open="true" action="hover" fixed="true" part="tooltip">Content</atom-tooltip>
+    `
+
+    it('should stay open after mouseleave when fixed', async () => {
+      const page = await newSpecPage({
+        components: [AtomTooltip],
+        html: fixedTooltip,
+      })
+
+      const element = page.body.querySelector('#fixed')
+
+      element?.dispatchEvent(new Event('mouseleave'))
+
+      await page.waitForChanges()
+
+      expect(
+        page.root?.shadowRoot?.querySelector('.atom-tooltip')
+      ).toHaveAttribute('data-show')
+    })
+
+    it('should stay open after outside click when fixed', async () => {
+      const page = await newSpecPage({
+        components: [AtomTooltip],
+        html: fixedTooltip,
+      })
+
+      page.body.dispatchEvent(new Event('click', { bubbles: true }))
+
+      await page.waitForChanges()
+
+      expect(
+        page.root?.shadowRoot?.querySelector('.atom-tooltip')
+      ).toHaveAttribute('data-show')
+    })
+
+    it('should close when close button is clicked when fixed', async () => {
+      const page = await newSpecPage({
+        components: [AtomTooltip],
+        html: fixedTooltip,
+      })
+
+      const closeButton = page.root?.shadowRoot?.querySelector(
+        '.atom-tooltip__action--close'
+      ) as HTMLElement
+
+      closeButton?.click()
+
+      await page.waitForChanges()
+
+      expect(
+        page.root?.shadowRoot?.querySelector('.atom-tooltip')
+      ).toHaveAttribute('data-hide')
+    })
+  })
 })

--- a/packages/core/src/components/tooltip/tooltip.tsx
+++ b/packages/core/src/components/tooltip/tooltip.tsx
@@ -62,6 +62,8 @@ export class AtomTooltip {
 
   @Prop() action: 'hover' | 'click' = 'hover'
 
+  @Prop({ mutable: true }) fixed = false
+
   @Watch('action')
   updateEvents() {
     this.untachEvents()
@@ -218,6 +220,16 @@ export class AtomTooltip {
   }
 
   private readonly hide = () => {
+    if (this.fixed) return
+
+    this._doHide()
+  }
+
+  private readonly forceHide = () => {
+    this._doHide()
+  }
+
+  private readonly _doHide = () => {
     this.open = false
     this.atomClose.emit()
 
@@ -248,11 +260,11 @@ export class AtomTooltip {
           <div class='atom-tooltip__content'>
             <slot />
 
-            {(this.action === 'click' || isMobile()) && (
+            {(this.action === 'click' || isMobile() || this.fixed) && (
               <button
                 class='atom-tooltip__action--close'
                 aria-label='Fechar'
-                onClick={this.hide}
+                onClick={this.forceHide}
               >
                 <atom-icon icon='close'></atom-icon>
               </button>


### PR DESCRIPTION
## Summary

- Adds `fixed` prop to `atom-tooltip` that prevents all auto-close triggers (mouseleave, blur, outside click)
- When `fixed=true`, only the X button can dismiss the tooltip
- Close button is now also rendered when `fixed=true` (previously only on `action=click` or mobile)

## Changes

- `tooltip.tsx`: new `fixed` prop; `hide()` bails when `fixed`; `forceHide()` for X button; shared `_doHide()` helper
- `tooltip.spec.ts`: 3 new tests covering fixed behavior
- `tooltip.args.ts`: `fixed` argType + default
- All 3 story files: `fixed` prop wired + `Fixed` story added

## Test plan

- [ ] `npm test` passes
- [ ] Storybook `Fixed` story shows tooltip open with X button
- [ ] Hovering off / clicking outside does not close fixed tooltip
- [ ] Clicking X closes fixed tooltip