### PR TITLE
fix(core): prevent ssr crash in request submit polyfill

### DIFF
--- a/packages/core/src/polyfills/form-request-submit.js
+++ b/packages/core/src/polyfills/form-request-submit.js
@@ -62,4 +62,4 @@
       name
     )
   }
-})(typeof globalThis !== 'undefined' && globalThis.HTMLFormElement.prototype)
+})(typeof globalThis !== 'undefined' && globalThis.HTMLFormElement?.prototype)

--- a/packages/core/src/polyfills/form-request-submit.spec.js
+++ b/packages/core/src/polyfills/form-request-submit.spec.js
@@ -1,0 +1,15 @@
+describe('form-request-submit polyfill', () => {
+  it('should not throw when HTMLFormElement is undefined (SSR environment)', () => {
+    const original = globalThis.HTMLFormElement
+
+    delete globalThis.HTMLFormElement
+
+    expect(() => {
+      jest.isolateModules(() => {
+        require('./form-request-submit.js')
+      })
+    }).not.toThrow()
+
+    globalThis.HTMLFormElement = original
+  })
+})


### PR DESCRIPTION
[Task](https://juntossomosmais.monday.com/boards/5337789717/pulses/11949610815)

## Summary

Fix a crash in the `requestSubmit` polyfill (`packages/core/src/polyfills/form-request-submit.js`)
that caused Next.js SSR builds to fail with:
`TypeError: Cannot read properties of undefined (reading 'prototype')`

**Root cause:** The IIFE argument `globalThis.HTMLFormElement.prototype` was evaluated
eagerly in Node.js environments where `HTMLFormElement` does not exist (DOM-only API).
The `&&` short-circuit evaluation returned `true`, which then tried to access `.prototype`
on `undefined`, crashing before the internal `if (!prototype) return` guard could run.

**Fix:** Added optional chaining (`?.`) so `globalThis.HTMLFormElement?.prototype`
returns `undefined` instead of throwing, allowing the guard to exit cleanly.

- **Browser impact:** None — `HTMLFormElement` always exists in browsers.
- **SSR/Node.js impact:** Polyfill is now safely skipped via early return.

## Evidences

<!-- Place the evidence here: images, videos, etc. -->
