### PR TITLE
fix(core): prevent ionic palette injection per component bundle

### DIFF
--- a/packages/core/src/global/global.scss
+++ b/packages/core/src/global/global.scss
@@ -1,3 +1,8 @@
+/* Ionic's stock theme. Loaded here (once, via globalStyle) instead of through
+ * `injectGlobalPaths` in stencil.config.ts to prevent its `:root{--ion-color-*}`
+ * declarations from being baked into every per-component CSS bundle. */
+@use '@ionic/core/css/core.css' as *;
+
 /* We need to use `body` instead of `:root` because some components of Ionic are injected by demand, so we need to use it to override the variables of the components that are loaded later */
 
 body {

--- a/packages/core/stencil.config.ts
+++ b/packages/core/stencil.config.ts
@@ -116,10 +116,14 @@ export const config: Config = {
   namespace: 'core',
   plugins: [
     sass({
-      injectGlobalPaths: [
-        '../../node_modules/@atomium/scss-utils/index.scss',
-        '../../node_modules/@ionic/core/css/core.css',
-      ],
+      // Only inject Sass-only files (variables, mixins, functions) here.
+      // Files containing actual CSS rules (e.g. @ionic/core/css/core.css) MUST NOT
+      // be listed: Stencil prepends them to every component's SCSS, which causes
+      // their rules (including :root{--ion-color-*: …} from Ionic's stock palette)
+      // to be baked into every per-component CSS bundle and re-injected into the
+      // document head when each component hydrates, overriding the global theme.
+      // Pure CSS files belong in `src/global/global.scss` (loaded once via `globalStyle`).
+      injectGlobalPaths: ['../../node_modules/@atomium/scss-utils/index.scss'],
       includePaths: ['../../node_modules'],
       silenceDeprecations: ['if-function'],
     }),


### PR DESCRIPTION
## Problem

`@ionic/core/css/core.css` was listed in `injectGlobalPaths` in `stencil.config.ts`. Stencil prepends every entry in that array to **every component's SCSS at compile time**, so the full Ionic stock palette (`:root { --ion-color-primary: #0054e9; ... }`) was baked into each per-component lazy bundle.

When a component hydrated in the browser, its bundle was injected into the document `<head>`, re-applying the Ionic stock palette **after** the global theme's `body {}` overrides. Since `:root` and `body` have equal specificity (0,0,0,1), source order decided — and the late-injected `:root` rules won, overriding the custom theme colors.

This caused `color="primary"` on `<AtomButton>` (and other components) to render with Ionic's default blue (`#0054e9`) instead of the brand's primary color, in React 19 / Next.js App Router apps where concurrent hydration changes the component injection timing.

## Solution

- Remove `@ionic/core/css/core.css` from `injectGlobalPaths` — only pure Sass files (variables, mixins, functions with no output rules) belong there.
- Import it once in `src/global/global.scss` via `@use`, which compiles it into `dist/core/core.css` (Stencil's `globalStyle` output). This file is loaded once at page start, before any component hydrates.

## No breaking change

`@juntossomosmais/atomium/core.css` is already the documented required import for both React and Vue consumers (see `packages/react/README.md` and `packages/vue/README.md`). Both Storybook setups already import it. The only observable difference for consumers is that `core.css` is now slightly larger (it includes Ionic's base CSS), but all required styles remain available through the same import path.

## Test plan

- [ ] Build `packages/core` and verify `dist/core/core.css` includes Ionic's stock palette
- [ ] Verify per-component bundles no longer contain `:root { --ion-color-primary }` declarations
- [ ] Confirm Storybook (docs, docs-react, docs-vue) renders `color="primary"` buttons with the correct brand color
- [ ] Confirm no visual regressions in existing component stories

🤖 Generated with [Claude Code](https://claude.com/claude-code)