### PR TITLE
chore(deps): bump production-dependencies group

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,10 +13,10 @@
         "utils/*"
       ],
       "dependencies": {
-        "@ionic/core": "^8.8.1",
+        "@ionic/core": "^8.8.5",
         "@popperjs/core": "^2.11.8",
-        "@stencil/core": "^4.43.2",
-        "dompurify": "^3.3.3"
+        "@stencil/core": "^4.43.4",
+        "dompurify": "^3.4.2"
       },
       "devDependencies": {
         "@babel/core": "^7.29.0",
@@ -94,9 +94,9 @@
         "yarn": "please-use-npm"
       },
       "optionalDependencies": {
-        "@rollup/rollup-linux-x64-gnu": "4.59.0",
-        "sass-embedded-darwin-arm64": "^1.98.0",
-        "sass-embedded-linux-x64": "^1.98.0"
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "sass-embedded-darwin-arm64": "^1.99.0",
+        "sass-embedded-linux-x64": "^1.99.0"
       }
     },
     "apps/docs": {
@@ -2977,7 +2977,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@ionic/core": {
-      "version": "8.8.1",
+      "version": "8.8.8",
+      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-8.8.8.tgz",
+      "integrity": "sha512-GGvYtEzLtn1gBUC1/vb4pvA3gQzYskTNVIsvdTVIgnwLtdt70rwTibrZRSqmkyHeqpjg/u3+9XsM2c0kzc/V3w==",
       "license": "MIT",
       "dependencies": {
         "@stencil/core": "4.43.0",
@@ -5120,9 +5122,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
-      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
       "cpu": [
         "x64"
       ],
@@ -5296,7 +5298,9 @@
       }
     },
     "node_modules/@stencil/core": {
-      "version": "4.43.2",
+      "version": "4.43.4",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.43.4.tgz",
+      "integrity": "sha512-QWawMM1XIpSz4k+k+VyHZMr2YSxlCNAPWO/jTdJ+2kdgdN7ZQVEFZpc4WBm3E3mrDPTZ79lLcnIPa399bg4XOg==",
       "license": "MIT",
       "bin": {
         "stencil": "bin/stencil"
@@ -8953,7 +8957,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.3",
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.7.tgz",
+      "integrity": "sha512-2jBxDJY4RR06tQNy4w5FlFH7kfxsQZlufd0sbv+chfHCxeJwrFw2baUDsSwvBISD4K4RDbd0PTfy3uNXsR6siA==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -17605,6 +17611,20 @@
         "linux"
       ]
     },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/rollup/node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
@@ -17920,9 +17940,9 @@
       }
     },
     "node_modules/sass-embedded-darwin-arm64": {
-      "version": "1.98.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.98.0.tgz",
-      "integrity": "sha512-cgr1z9rBnCdMf8K+JabIaYd9Rag2OJi5mjq08XJfbJGMZV/TA6hFJCLGkr5/+ZOn4/geTM5/3aSfQ8z5EIJAOg==",
+      "version": "1.100.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.100.0.tgz",
+      "integrity": "sha512-1PVlYi61POo93IT/FfrG1mc1tAHxeSTyUALF2aOFmXGWjVXr3bQzEQiBGCOvQbj/ix+5hNyXFXcEMEyKvtUJJA==",
       "cpu": [
         "arm64"
       ],
@@ -18072,9 +18092,9 @@
       }
     },
     "node_modules/sass-embedded-linux-x64": {
-      "version": "1.98.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.98.0.tgz",
-      "integrity": "sha512-VsvP0t/uw00mMNPv3vwyYKUrFbqzxQHnRMO+bHdAMjvLw4NFf6mscpym9Bzf+NXwi1ZNKnB6DtXjmcpcvqFqYg==",
+      "version": "1.100.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.100.0.tgz",
+      "integrity": "sha512-0vUSN8j0WGtCJIOPh//EmUvYGHW0QOe5iul8qyhPk50MAcw49MA0r34AhftjDdx94ILPF6vApFs0gwHPQRlpVA==",
       "cpu": [
         "x64"
       ],
@@ -18133,6 +18153,40 @@
       "optional": true,
       "os": [
         "win32"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded/node_modules/sass-embedded-darwin-arm64": {
+      "version": "1.98.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.98.0.tgz",
+      "integrity": "sha512-cgr1z9rBnCdMf8K+JabIaYd9Rag2OJi5mjq08XJfbJGMZV/TA6hFJCLGkr5/+ZOn4/geTM5/3aSfQ8z5EIJAOg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded/node_modules/sass-embedded-linux-x64": {
+      "version": "1.98.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.98.0.tgz",
+      "integrity": "sha512-VsvP0t/uw00mMNPv3vwyYKUrFbqzxQHnRMO+bHdAMjvLw4NFf6mscpym9Bzf+NXwi1ZNKnB6DtXjmcpcvqFqYg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
       ],
       "engines": {
         "node": ">=14.0.0"
@@ -20677,7 +20731,7 @@
     },
     "packages/core": {
       "name": "@juntossomosmais/atomium",
-      "version": "3.19.0"
+      "version": "3.19.2"
     },
     "packages/icons": {
       "name": "@juntossomosmais/atomium-icons"

--- a/package.json
+++ b/package.json
@@ -30,10 +30,10 @@
     "tokens:build": "nx build @juntossomosmais/atomium-tokens"
   },
   "dependencies": {
-    "@ionic/core": "^8.8.1",
+    "@ionic/core": "^8.8.5",
     "@popperjs/core": "^2.11.8",
-    "@stencil/core": "^4.43.2",
-    "dompurify": "^3.3.3"
+    "@stencil/core": "^4.43.4",
+    "dompurify": "^3.4.2"
   },
   "devDependencies": {
     "@babel/core": "^7.29.0",
@@ -106,9 +106,9 @@
     "vue": "^3.5.30"
   },
   "optionalDependencies": {
-    "@rollup/rollup-linux-x64-gnu": "4.59.0",
-    "sass-embedded-darwin-arm64": "^1.98.0",
-    "sass-embedded-linux-x64": "^1.98.0"
+    "@rollup/rollup-linux-x64-gnu": "4.60.2",
+    "sass-embedded-darwin-arm64": "^1.99.0",
+    "sass-embedded-linux-x64": "^1.99.0"
   },
   "overrides": {
     "sass-embedded": "1.98.0"


### PR DESCRIPTION
## Summary

Applies the production-dependencies group bumps from #819 onto a fresh branch off current `main` (the Dependabot branch was stale against recent release commits). All six are runtime/build deps, so each was reviewed individually.

## Changes

| Package | From → To | Notes |
| --- | --- | --- |
| `@ionic/core` | `^8.8.1` → `^8.8.5` | patch; resolved to 8.8.8 in lockfile |
| `@stencil/core` | `^4.43.2` → `^4.43.4` | patch; core compiler/runtime |
| `dompurify` | `^3.3.3` → `^3.4.2` | minor; resolved to 3.4.7. Security sanitizer used in `alert.tsx` and `stepper.tsx` via the stable `DOMPurify.sanitize()` API — unchanged, covered by specs |
| `@rollup/rollup-linux-x64-gnu` | `4.59.0` → `4.60.2` | optional platform binary (build-time) |
| `sass-embedded-darwin-arm64` | `^1.98.0` → `^1.99.0` | optional platform binary (build-time) |
| `sass-embedded-linux-x64` | `^1.98.0` → `^1.99.0` | optional platform binary (build-time) |

`overrides.sass-embedded` is left pinned at `1.98.0`, matching Dependabot's output for this group.

## Verification

- `npm run build` — all packages build ✅
- `npm test` — 227 passed, 1 skipped ✅ (includes `alert` / `stepper` sanitize coverage)
- `npm audit --omit=dev` — **0 vulnerabilities** in production deps ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
