### PR TITLE
docs(adr): use year-month prefix for adr filenames and titles

### DIFF
--- a/apps/docs/stories/architecture-decision-records/2023-03-why-a-monorepo.mdx
+++ b/apps/docs/stories/architecture-decision-records/2023-03-why-a-monorepo.mdx
@@ -1,8 +1,8 @@
 import { Meta } from '@storybook/addon-docs/blocks'
 
-<Meta title="Docs/Architecture Decision Records/ADR 0004: Why a Monorepo?" />
+<Meta title="Docs/Architecture Decision Records/2023-03: Why a Monorepo?" />
 
-# ADR 0004: Why a Monorepo?
+# 2023-03: Why a Monorepo?
 
 🗓️ 2023-03 · ✍️ [@felipefialho](https://twitter.com/felipefialho_)
 

--- a/apps/docs/stories/architecture-decision-records/2023-03-why-design-system.mdx
+++ b/apps/docs/stories/architecture-decision-records/2023-03-why-design-system.mdx
@@ -1,8 +1,8 @@
 import { Meta } from '@storybook/addon-docs/blocks'
 
-<Meta title="Docs/Architecture Decision Records/ADR 0000: Why Design System?" />
+<Meta title="Docs/Architecture Decision Records/2023-03: Why Design System?" />
 
-# ADR 0000: Why Design System?
+# 2023-03: Why Design System?
 
 🗓️ 2023-03 · ✍️ [@felipefialho](https://twitter.com/felipefialho_)
 

--- a/apps/docs/stories/architecture-decision-records/2023-03-why-ionic.mdx
+++ b/apps/docs/stories/architecture-decision-records/2023-03-why-ionic.mdx
@@ -1,8 +1,8 @@
 import { Meta } from '@storybook/addon-docs/blocks'
 
-<Meta title="Docs/Architecture Decision Records/ADR 0002: Why Ionic?" />
+<Meta title="Docs/Architecture Decision Records/2023-03: Why Ionic?" />
 
-# ADR 0002: Why Ionic?
+# 2023-03: Why Ionic?
 
 🗓️ 2023-03 · ✍️ [@felipefialho](https://twitter.com/felipefialho_)
 

--- a/apps/docs/stories/architecture-decision-records/2023-03-why-nx.mdx
+++ b/apps/docs/stories/architecture-decision-records/2023-03-why-nx.mdx
@@ -1,8 +1,8 @@
 import { Meta } from '@storybook/addon-docs/blocks'
 
-<Meta title="Docs/Architecture Decision Records/ADR 0005: Why NX?" />
+<Meta title="Docs/Architecture Decision Records/2023-03: Why NX?" />
 
-# ADR 0005: Why NX?
+# 2023-03: Why NX?
 
 🗓️ 2023-03 · ✍️ [@felipefialho](https://twitter.com/felipefialho_)
 

--- a/apps/docs/stories/architecture-decision-records/2023-03-why-stencil.mdx
+++ b/apps/docs/stories/architecture-decision-records/2023-03-why-stencil.mdx
@@ -1,8 +1,8 @@
 import { Meta } from '@storybook/addon-docs/blocks'
 
-<Meta title="Docs/Architecture Decision Records/ADR 0003: Why Stencil?" />
+<Meta title="Docs/Architecture Decision Records/2023-03: Why Stencil?" />
 
-# ADR 0003: Why Stencil?
+# 2023-03: Why Stencil?
 
 🗓️ 2023-03 · ✍️ [@felipefialho](https://twitter.com/felipefialho_)
 

--- a/apps/docs/stories/architecture-decision-records/2023-03-why-that-component-creation-definition.mdx
+++ b/apps/docs/stories/architecture-decision-records/2023-03-why-that-component-creation-definition.mdx
@@ -1,8 +1,8 @@
 import { Meta } from '@storybook/addon-docs/blocks'
 
-<Meta title="Docs/Architecture Decision Records/ADR 0006: Why that component creation definition?" />
+<Meta title="Docs/Architecture Decision Records/2023-03: Why that component creation definition?" />
 
-# ADR 0006: Why that component creation definition?
+# 2023-03: Why that component creation definition?
 
 🗓️ 2023-03 · ✍️ [@felipefialho](https://twitter.com/felipefialho_)
 

--- a/apps/docs/stories/architecture-decision-records/2023-03-why-web-components.mdx
+++ b/apps/docs/stories/architecture-decision-records/2023-03-why-web-components.mdx
@@ -1,8 +1,8 @@
 import { Meta } from '@storybook/addon-docs/blocks'
 
-<Meta title="Docs/Architecture Decision Records/ADR 0001: Why Web Components?" />
+<Meta title="Docs/Architecture Decision Records/2023-03: Why Web Components?" />
 
-# ADR 0001: Why Web Components?
+# 2023-03: Why Web Components?
 
 🗓️ 2023-03 · ✍️ [@felipefialho](https://twitter.com/felipefialho_)
 

--- a/apps/docs/stories/architecture-decision-records/2023-05-why-do-we-need-grids.mdx
+++ b/apps/docs/stories/architecture-decision-records/2023-05-why-do-we-need-grids.mdx
@@ -1,8 +1,8 @@
 import { Meta } from '@storybook/addon-docs/blocks'
 
-<Meta title="Docs/Architecture Decision Records/ADR 0008: Why do we need Grids" />
+<Meta title="Docs/Architecture Decision Records/2023-05: Why do we need Grids" />
 
-# ADR 0008: Why do we need Grids
+# 2023-05: Why do we need Grids
 
 🗓️ 2023-05 · ✍️ [@mauriciomutte](https://twitter.com/mauriciomutte) and [@felipefialho](https://twitter.com/felipefialho_)
 

--- a/apps/docs/stories/architecture-decision-records/2023-07-why-do-we-need-react-fix.mdx
+++ b/apps/docs/stories/architecture-decision-records/2023-07-why-do-we-need-react-fix.mdx
@@ -1,8 +1,8 @@
 import { Meta } from '@storybook/addon-docs/blocks'
 
-<Meta title="Docs/Architecture Decision Records/ADR 0010: Why do we need a fix in React?" />
+<Meta title="Docs/Architecture Decision Records/2023-07: Why do we need a fix in React?" />
 
-# ADR 0010: Why do we need a fix in React?
+# 2023-07: Why do we need a fix in React?
 
 🗓️ 2023-07 · ✍️ [@igorwessel](https://twitter.com/igor_wessel)
 

--- a/apps/docs/stories/architecture-decision-records/2023-07-why-host-our-own-icon-library-and-cdn.mdx
+++ b/apps/docs/stories/architecture-decision-records/2023-07-why-host-our-own-icon-library-and-cdn.mdx
@@ -1,8 +1,8 @@
 import { Meta } from '@storybook/addon-docs/blocks'
 
-<Meta title="Docs/Architecture Decision Records/ADR 0011: Why host our own icon library and why CDN?" />
+<Meta title="Docs/Architecture Decision Records/2023-07: Why host our own icon library and why CDN?" />
 
-# ADR 0011: Why host our own icon library and why CDN?
+# 2023-07: Why host our own icon library and why CDN?
 
 🗓️ 2023-07 · ✍️ [@mauriciomutte](https://twitter.com/mauriciomutte)
 

--- a/apps/docs/stories/architecture-decision-records/2023-07-why-use-onclick-event-on-breadcrumb-component-event-undocumented.mdx
+++ b/apps/docs/stories/architecture-decision-records/2023-07-why-use-onclick-event-on-breadcrumb-component-event-undocumented.mdx
@@ -1,8 +1,8 @@
 import { Meta } from '@storybook/addon-docs/blocks'
 
-<Meta title="Docs/Architecture Decision Records/ADR 0009: Why use onClick event on breadcrumb component even undocumented?" />
+<Meta title="Docs/Architecture Decision Records/2023-07: Why use onClick event on breadcrumb component even undocumented?" />
 
-# Why use `onClick` event on breadcrumb component even undocumented?
+# 2023-07: Why use `onClick` event on breadcrumb component even undocumented?
 
 🗓️ 2023-07 · ✍️ [@denilsonrp](https://github.com/denilsonrp)
 

--- a/apps/docs/stories/architecture-decision-records/2023-08-why-do-we-need-to-convert-carousel-item.mdx
+++ b/apps/docs/stories/architecture-decision-records/2023-08-why-do-we-need-to-convert-carousel-item.mdx
@@ -1,8 +1,8 @@
 import { Meta } from '@storybook/addon-docs/blocks'
 
-<Meta title="Docs/Architecture Decision Records/ADR 0013: Why do we need to convert carousel item" />
+<Meta title="Docs/Architecture Decision Records/2023-08: Why do we need to convert carousel item" />
 
-# ADR 0013: Why do we need to convert carousel item
+# 2023-08: Why do we need to convert carousel item
 
 🗓️ 2023-08 · ✍️ [@schirrel](https://github.com/schirrel), [@MayaraRMA](https://github.com/MayaraRMA), [@tassioFront](https://github.com/tassioFront) and [@felipefialho](https://twitter.com/felipefialho_)
 

--- a/apps/docs/stories/architecture-decision-records/2023-08-why-have-a-carousel-with-swiper.mdx
+++ b/apps/docs/stories/architecture-decision-records/2023-08-why-have-a-carousel-with-swiper.mdx
@@ -1,8 +1,8 @@
 import { Meta } from '@storybook/addon-docs/blocks'
 
-<Meta title="Docs/Architecture Decision Records/ADR 0012: Carousel with Swiper" />
+<Meta title="Docs/Architecture Decision Records/2023-08: Carousel with Swiper" />
 
-# ADR 0012: Carousel with Swiper
+# 2023-08: Carousel with Swiper
 
 🗓️ 2023-08 · ✍️ [@schirrel](https://github.com/schirrel), [@MayaraRMA](https://github.com/MayaraRMA), [@tassioFront](https://github.com/tassioFront) and [@felipefialho](https://twitter.com/felipefialho_)
 

--- a/apps/docs/stories/architecture-decision-records/2024-05-why-do-we-transpile-web-components-for-react-and-vue.mdx
+++ b/apps/docs/stories/architecture-decision-records/2024-05-why-do-we-transpile-web-components-for-react-and-vue.mdx
@@ -1,8 +1,8 @@
 import { Meta } from '@storybook/addon-docs/blocks'
 
-<Meta title="Docs/Architecture Decision Records/ADR 0007: Why do we transpile Web Components for React and Vue?" />
+<Meta title="Docs/Architecture Decision Records/2024-05: Why do we transpile Web Components for React and Vue?" />
 
-# ADR 0007: Why do we transpile Web Components for React and Vue?
+# 2024-05: Why do we transpile Web Components for React and Vue?
 
 🗓️ ~2023-04~ 2024-05 · ✍️ [@felipefialho](https://twitter.com/felipefialho_)
 

--- a/apps/docs/stories/architecture-decision-records/2024-11-why-use-popperjs.mdx
+++ b/apps/docs/stories/architecture-decision-records/2024-11-why-use-popperjs.mdx
@@ -1,8 +1,8 @@
 import { Meta } from '@storybook/addon-docs/blocks'
 
-<Meta title="Docs/Architecture Decision Records/ADR 0014: Why PopperJS" />
+<Meta title="Docs/Architecture Decision Records/2024-11: Why PopperJS" />
 
-# ADR 0014: Why PopperJS
+# 2024-11: Why PopperJS
 
 🗓️ 2024-11 · ✍️ [@igorwessel](https://github.com/igorwessel)
 

--- a/apps/docs/stories/architecture-decision-records/2025-03-why-use-cdn-for-distribution.mdx
+++ b/apps/docs/stories/architecture-decision-records/2025-03-why-use-cdn-for-distribution.mdx
@@ -1,8 +1,8 @@
 import { Meta } from '@storybook/addon-docs/blocks'
 
-<Meta title='Docs/Architecture Decision Records/ADR 0015: Why use a CDN for Atomium distribution' />
+<Meta title='Docs/Architecture Decision Records/2025-03: Why use a CDN for Atomium distribution' />
 
-# ADR 0015: Why use a CDN for Atomium distribution
+# 2025-03: Why use a CDN for Atomium distribution
 
 🗓️ 2025-03 · ✍️ [@felipefialho](https://twitter.com/felipefialho_)
 

--- a/apps/docs/stories/architecture-decision-records/2025-11-why-react-19-compatibility-patch.mdx
+++ b/apps/docs/stories/architecture-decision-records/2025-11-why-react-19-compatibility-patch.mdx
@@ -1,8 +1,8 @@
 import { Meta } from '@storybook/addon-docs/blocks'
 
-<Meta title="Docs/Architecture Decision Records/ADR 0016: Why React 19 compatibility patch?" />
+<Meta title="Docs/Architecture Decision Records/2025-11: Why React 19 compatibility patch?" />
 
-# ADR 0016: Why React 19 compatibility patch?
+# 2025-11: Why React 19 compatibility patch?
 
 🗓️ 2025-11 · ✍️ [@felipefialho](https://twitter.com/felipefialho_)
 
@@ -168,4 +168,4 @@ Comprehensive test suite in `packages/core/output-target/react-19-fix.spec.ts` v
 * [Stencil Custom Output Targets](https://stenciljs.com/docs/output-targets#custom-output-targets)
 * Output Target Implementation: `packages/core/output-target/react-19-fix.ts`
 * Test Suite: `packages/core/output-target/react-19-fix.spec.ts`
-* Related: ADR 0010 (React Boolean Fix) - Similar pattern
+* Related: [2023-07: Why do we need a fix in React?](./2023-07-why-do-we-need-react-fix.mdx) (React Boolean Fix) - Similar pattern


### PR DESCRIPTION
## What

Renames all Architecture Decision Records to use the decision **date (year-month)** as the prefix instead of the sequential `00XX` numbering. The change is applied consistently across:

- filenames (`0010-why-do-we-need-react-fix.mdx` → `2023-07-why-do-we-need-react-fix.mdx`)
- Storybook `<Meta title>` entries
- H1 headings

## Why

The sequential numbering made it hard to see when a decision was made and forced manual bookkeeping for the next number (it had already caused an `0016` collision). A date prefix is self-describing and orders naturally.

## Details

- Dates come from each ADR's documented decision date (`🗓️` line). Month-only dates are kept as `year-month`.
- ADR 0007 (`~2023-04~ 2024-05`) uses its latest revision date, `2024-05`.
- The single textual cross-reference (`Related: ADR 0010` in the React 19 ADR) was updated to a date-based link.
- No `storySort` is configured, so the sidebar now orders ADRs chronologically by the date prefix (agreed trade-off; same-month ADRs group together).

## Notes

This is the repo-wide rename agreed as a separate PR. The in-flight `feat/update-react-output-target` branch already adopts this pattern for its new ADR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)