### PR TITLE
fix(tokens): add 'types' condition to exports for bundler module resolution

### DIFF
--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -18,6 +18,7 @@
   "exports": {
     "./*": "./dist/*",
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     }


### PR DESCRIPTION
## Problem

TypeScript with `\"moduleResolution\": \"bundler\"` (recommended for Next.js 13+ and modern bundlers) ignores the root-level `\"types\"` field and requires an explicit `\"types\"` condition inside the `exports` map. Without it, importing from `@juntossomosmais/atomium-tokens` produces:

```
error TS7016: Could not find a declaration file for module '@juntossomosmais/atomium-tokens'.
There are types at 'dist/index.d.ts', but this result could not be resolved when respecting
package.json "exports". The library may need to update its package.json or typings.
```

## Fix

Add `\"types\": \"./dist/index.d.ts\"` as the first condition in the `.` export entry (TypeScript requires it to come before `import`/`require`).

```diff
 "exports": {
   "./*": "./dist/*",
   ".": {
+    "types": "./dist/index.d.ts",
     "import": "./dist/index.mjs",
     "require": "./dist/index.js"
   }
 }
```

## Affected projects (confirmed)

After this fix ships as **2.1.2**, each project can drop its workaround and pin to `^2.1.2`.