### PR TITLE
fix(meter): replace deprecated word-wrap with overflow-wrap

### DIFF
--- a/packages/core/src/components/meter/meter.scss
+++ b/packages/core/src/components/meter/meter.scss
@@ -3,8 +3,8 @@
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
+  overflow-wrap: break-word;
   width: 100%;
-  word-wrap: break-word;
 }
 
 .container-text {


### PR DESCRIPTION
## What

Replaces the deprecated `word-wrap` property with its modern equivalent `overflow-wrap` in the `meter` component styles, and repositions it to keep declarations alphabetical.

## Why

`stylelint`'s `property-no-deprecated` rule flags `word-wrap: break-word` in `meter.scss`. `overflow-wrap` is the standardized property with identical behavior.

## Verification
- ✅ `stylelint packages/core/src/components/meter/meter.scss` — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)