### PR TITLE
chore(deps): bump production-dependencies group

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       "dependencies": {
         "@ionic/core": "^8.8.5",
         "@popperjs/core": "^2.11.8",
-        "@stencil/core": "^4.43.4",
+        "@stencil/core": "^4.43.5",
         "dompurify": "^3.4.2"
       },
       "devDependencies": {
@@ -5982,9 +5982,9 @@
       }
     },
     "node_modules/@stencil/core": {
-      "version": "4.43.4",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.43.4.tgz",
-      "integrity": "sha512-QWawMM1XIpSz4k+k+VyHZMr2YSxlCNAPWO/jTdJ+2kdgdN7ZQVEFZpc4WBm3E3mrDPTZ79lLcnIPa399bg4XOg==",
+      "version": "4.43.5",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.43.5.tgz",
+      "integrity": "sha512-cgWD+GeuvJpTe1WQn40p02+BJ2j0j1YJ17GdkF2qKIQ23s2e3Zivq5yISXS3dcuV6oUJFN93jprdk+nk/sq99Q==",
       "license": "MIT",
       "bin": {
         "stencil": "bin/stencil"
@@ -12772,6 +12772,7 @@
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -13558,6 +13559,7 @@
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -16472,7 +16474,9 @@
       "license": "MIT"
     },
     "node_modules/react": {
-      "version": "19.2.6",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -20687,9 +20691,11 @@
     "packages/react": {
       "name": "@juntossomosmais/atomium-react",
       "dependencies": {
-        "@stencil/react-output-target": "^1.5.3",
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "@stencil/react-output-target": "^1.5.3"
+      },
+      "devDependencies": {
+        "react": "^19.2.7",
+        "react-dom": "^19.2.7"
       },
       "peerDependencies": {
         "react": ">=17.0.0",
@@ -20700,6 +20706,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -20709,25 +20716,16 @@
       }
     },
     "packages/react/node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
+        "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^18.3.1"
-      }
-    },
-    "packages/react/node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
+        "react": "^19.2.7"
       }
     },
     "packages/tokens": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@ionic/core": "^8.8.5",
     "@popperjs/core": "^2.11.8",
-    "@stencil/core": "^4.43.4",
+    "@stencil/core": "^4.43.5",
     "dompurify": "^3.4.2"
   },
   "devDependencies": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -40,9 +40,11 @@
     }
   },
   "dependencies": {
-    "@stencil/react-output-target": "^1.5.3",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "@stencil/react-output-target": "^1.5.3"
+  },
+  "devDependencies": {
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7"
   },
   "peerDependencies": {
     "react": ">=17.0.0",


### PR DESCRIPTION
## What

Updates the production-dependencies group from #834, with two adjustments after careful review of consumer impact.

Supersedes #834, whose `build-and-test` failed only on a `401 Unauthorized` fetching the private `@juntossomosmais/rupture-scss` package (Dependabot has no registry token) — the dependency changes themselves were never actually tested. This branch was verified locally with proper registry auth.

## Updates

- `@stencil/core` 4.43.4 → **4.43.5** (root `dependencies`) — patch, bug-fixes only.
- `react`, `react-dom` 18.3.1 → **^19.2.7** in `packages/react` — and **moved from `dependencies` to `devDependencies`** (see below).

## Consumer-impact analysis

None of these change the published consumer contract:

- `packages/react` (`@juntossomosmais/atomium-react`) is **`private: true`** — not published. Its build output is copied into `@juntossomosmais/atomium`, so its `react` version is **build-time only**.
- The actual consumer contract is `@juntossomosmais/atomium`'s **optional `peerDependency` `react >=18`** (unchanged).
- `@stencil/core` is a build-time root dependency (not in the published package's deps).

## Why move react to `devDependencies`

`packages/react` declared `react`/`react-dom` in **both** `dependencies` and `peerDependencies` — an anti-pattern for a wrapper library (risks a duplicate React instance in consumer trees → "invalid hook call"). They're now `devDependencies` (used to build/typecheck the wrapper) + `peerDependencies` (the consumer contract). The repo already builds on React 19 at the root, so this aligns `packages/react` with it.

## Not included (handled elsewhere)

- `@rollup/rollup-linux-x64-gnu` 4.60.2 → 4.61.0 (from #834) is **omitted** — that `optionalDependency` is being removed entirely in #838 as an obsolete npm-bug workaround.

## Verification (local, with registry auth)
- ✅ `npm install --legacy-peer-deps` + `npm run build` — core, react, vue
- ✅ `npm test` — 213 passed / 27 suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)
