### PR TITLE
fix(datetime): live range fill with default buttons and value hardening

### DIFF
--- a/packages/core/src/components/datetime/datetime.spec.ts
+++ b/packages/core/src/components/datetime/datetime.spec.ts
@@ -556,6 +556,114 @@ describe('AtomDatetime', () => {
     expect(ionDatetime?.hasAttribute('multiple')).toBe(true)
   })
 
+  describe('live range fill while the calendar is open', () => {
+    const buildCalendarDay = (isoDate: string): HTMLElement => {
+      const [year, month, day] = isoDate.split('-')
+      const element = document.createElement('button')
+
+      element.setAttribute('part', 'calendar-day active')
+      element.setAttribute('data-year', year)
+      element.setAttribute('data-month', String(Number(month)))
+      element.setAttribute('data-day', String(Number(day)))
+
+      return element
+    }
+
+    const buildRangeModePage = async () =>
+      newSpecPage({
+        components: [AtomDatetime],
+        html: '<atom-datetime range-mode="true"></atom-datetime>',
+      })
+
+    it('expands two selected endpoints into a contiguous range', async () => {
+      const page = await buildRangeModePage()
+      const datetime = page.rootInstance
+
+      expect(
+        datetime.getFilledRangeFromSelection(['2022-01-01', '2022-01-04'])
+      ).toEqual(['2022-01-01', '2022-01-02', '2022-01-03', '2022-01-04'])
+    })
+
+    it('returns null when fewer than two dates are selected', async () => {
+      const page = await buildRangeModePage()
+      const datetime = page.rootInstance
+
+      expect(datetime.getFilledRangeFromSelection(['2022-01-01'])).toBeNull()
+    })
+
+    it('returns null when the selection is already contiguous', async () => {
+      const page = await buildRangeModePage()
+      const datetime = page.rootInstance
+
+      expect(
+        datetime.getFilledRangeFromSelection([
+          '2022-01-01',
+          '2022-01-02',
+          '2022-01-03',
+        ])
+      ).toBeNull()
+    })
+
+    it('reads an ISO date from a calendar-day element', async () => {
+      const page = await buildRangeModePage()
+      const datetime = page.rootInstance
+
+      expect(
+        datetime.readCalendarDayIsoDate(buildCalendarDay('2022-03-07'))
+      ).toBe('2022-03-07')
+    })
+
+    it('returns null when a calendar-day element has no date data', async () => {
+      const page = await buildRangeModePage()
+      const datetime = page.rootInstance
+
+      expect(
+        datetime.readCalendarDayIsoDate(document.createElement('button'))
+      ).toBeNull()
+    })
+
+    it('applies the filled range to the active calendar days', async () => {
+      const page = await buildRangeModePage()
+      const datetime = page.rootInstance
+
+      datetime._datetimeEl = {
+        shadowRoot: {
+          querySelectorAll: () => [
+            buildCalendarDay('2022-01-01'),
+            buildCalendarDay('2022-01-03'),
+          ],
+        },
+      }
+
+      datetime.fillVisibleRange()
+
+      expect(datetime.ionDatetimeValue).toEqual([
+        '2022-01-01',
+        '2022-01-02',
+        '2022-01-03',
+      ])
+    })
+
+    it('does not change the value when the active days are already contiguous', async () => {
+      const page = await buildRangeModePage()
+      const datetime = page.rootInstance
+
+      datetime.ionDatetimeValue = undefined
+      datetime._datetimeEl = {
+        shadowRoot: {
+          querySelectorAll: () => [
+            buildCalendarDay('2022-01-01'),
+            buildCalendarDay('2022-01-02'),
+          ],
+        },
+      }
+
+      datetime.fillVisibleRange()
+
+      expect(datetime.ionDatetimeValue).toBeUndefined()
+    })
+  })
+
   describe('deferred ion-datetime value updates', () => {
     it('applies the latest scheduled value once the timer runs', async () => {
       const page = await newSpecPage({

--- a/packages/core/src/components/datetime/datetime.spec.ts
+++ b/packages/core/src/components/datetime/datetime.spec.ts
@@ -561,6 +561,7 @@ describe('AtomDatetime', () => {
       const [year, month, day] = isoDate.split('-')
       const element = document.createElement('button')
 
+      element.classList.add('calendar-day')
       element.setAttribute('part', 'calendar-day active')
       element.setAttribute('data-year', year)
       element.setAttribute('data-month', String(Number(month)))
@@ -661,6 +662,84 @@ describe('AtomDatetime', () => {
       datetime.fillVisibleRange()
 
       expect(datetime.ionDatetimeValue).toBeUndefined()
+    })
+
+    it('moves the click listener between datetime elements', async () => {
+      const page = await buildRangeModePage()
+      const datetime = page.rootInstance
+      const first = {
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+      }
+      const second = {
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+      }
+
+      datetime.datetimeEl = first
+      datetime.datetimeEl = second
+
+      expect(first.addEventListener).toHaveBeenCalledWith(
+        'click',
+        expect.any(Function)
+      )
+      expect(first.removeEventListener).toHaveBeenCalledWith(
+        'click',
+        expect.any(Function)
+      )
+      expect(second.addEventListener).toHaveBeenCalledWith(
+        'click',
+        expect.any(Function)
+      )
+    })
+
+    it('removes the click listener on disconnect', async () => {
+      const page = await buildRangeModePage()
+      const datetime = page.rootInstance
+      const element = {
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+      }
+
+      datetime.datetimeEl = element
+      datetime.disconnectedCallback()
+
+      expect(element.removeEventListener).toHaveBeenCalledWith(
+        'click',
+        expect.any(Function)
+      )
+    })
+
+    it('ignores clicks that are not on a calendar day', async () => {
+      const page = await buildRangeModePage()
+      const datetime = page.rootInstance
+      const rafSpy = jest
+        .spyOn(globalThis, 'requestAnimationFrame')
+        .mockImplementation(() => 0)
+
+      datetime.handleRangeFillClick({
+        composedPath: () => [document.createElement('div')],
+      })
+
+      expect(rafSpy).not.toHaveBeenCalled()
+
+      rafSpy.mockRestore()
+    })
+
+    it('schedules a range fill when a calendar day is clicked', async () => {
+      const page = await buildRangeModePage()
+      const datetime = page.rootInstance
+      const rafSpy = jest
+        .spyOn(globalThis, 'requestAnimationFrame')
+        .mockImplementation(() => 0)
+
+      datetime.handleRangeFillClick({
+        composedPath: () => [buildCalendarDay('2022-01-01')],
+      })
+
+      expect(rafSpy).toHaveBeenCalled()
+
+      rafSpy.mockRestore()
     })
   })
 

--- a/packages/core/src/components/datetime/datetime.spec.ts
+++ b/packages/core/src/components/datetime/datetime.spec.ts
@@ -555,4 +555,39 @@ describe('AtomDatetime', () => {
 
     expect(ionDatetime?.hasAttribute('multiple')).toBe(true)
   })
+
+  describe('deferred ion-datetime value updates', () => {
+    it('applies the latest scheduled value once the timer runs', async () => {
+      const page = await newSpecPage({
+        components: [AtomDatetime],
+        html: '<atom-datetime range-mode="true"></atom-datetime>',
+      })
+      const datetime = page.rootInstance
+
+      jest.useFakeTimers()
+      datetime.scheduleIonDatetimeValue(() => ['2022-01-01'])
+      datetime.scheduleIonDatetimeValue(() => ['2022-02-02'])
+      jest.runAllTimers()
+      jest.useRealTimers()
+
+      expect(datetime.ionDatetimeValue).toEqual(['2022-02-02'])
+    })
+
+    it('cancels a pending value update when the component disconnects', async () => {
+      const page = await newSpecPage({
+        components: [AtomDatetime],
+        html: '<atom-datetime range-mode="true"></atom-datetime>',
+      })
+      const datetime = page.rootInstance
+
+      jest.useFakeTimers()
+      datetime.ionDatetimeValue = ['initial']
+      datetime.scheduleIonDatetimeValue(() => ['deferred'])
+      datetime.disconnectedCallback()
+      jest.runAllTimers()
+      jest.useRealTimers()
+
+      expect(datetime.ionDatetimeValue).toEqual(['initial'])
+    })
+  })
 })

--- a/packages/core/src/components/datetime/datetime.tsx
+++ b/packages/core/src/components/datetime/datetime.tsx
@@ -74,7 +74,7 @@ export class AtomDatetime {
   @Prop() showDefaultTitle = false
   @Prop() useButton = false
   @Prop() size?: 'cover' | 'fixed' = 'fixed'
-  @Prop({ mutable: true, reflect: true }) value?: TValue
+  @Prop({ mutable: true }) value?: TValue
 
   @Prop() yearValues?: number[] | string
 

--- a/packages/core/src/components/datetime/datetime.tsx
+++ b/packages/core/src/components/datetime/datetime.tsx
@@ -87,6 +87,7 @@ export class AtomDatetime {
   @Event() atomCancel!: EventEmitter<void>
 
   private _datetimeEl!: HTMLIonDatetimeElement
+  private deferredValueTimeout?: ReturnType<typeof setTimeout>
 
   get datetimeEl(): HTMLIonDatetimeElement {
     return this._datetimeEl
@@ -142,6 +143,36 @@ export class AtomDatetime {
     return undefined
   }
 
+  private getDeferredIonValue(): string[] | undefined {
+    if (this.rangeMode) return [...this.selectedDates]
+
+    if (this.selectedDates.length > 0) return [this.selectedDates[0]]
+
+    return undefined
+  }
+
+  // WORKAROUND: ion-datetime can reset to a default year (e.g. 2021) when its
+  // value is set too early during render. Deferring the assignment with
+  // setTimeout(0) lets ion-datetime finish rendering first. The timeout is
+  // tracked so it can be cancelled on disconnect and never resolves against an
+  // unmounted component.
+  private scheduleIonDatetimeValue(getValue: () => string[] | undefined) {
+    if (this.deferredValueTimeout) {
+      clearTimeout(this.deferredValueTimeout)
+    }
+
+    this.deferredValueTimeout = setTimeout(() => {
+      this.deferredValueTimeout = undefined
+      this.ionDatetimeValue = getValue()
+    }, 0)
+  }
+
+  disconnectedCallback() {
+    if (this.deferredValueTimeout) {
+      clearTimeout(this.deferredValueTimeout)
+    }
+  }
+
   componentWillLoad() {
     const normalizedValue = this.normalizeValue(this.value)
 
@@ -153,22 +184,7 @@ export class AtomDatetime {
       this.selectedDates = []
     }
 
-    // WORKAROUND: Ionic's ion-datetime can sometimes reset to a default year (e.g., 2021)
-    // if its 'value' prop is set too early during component initialization or state updates.
-    // Setting the value with a setTimeout(..., 0) allows the ion-datetime to fully render
-    // before its value is programmatically applied, preventing this bug.
-    setTimeout(() => {
-      let valueToSet: string[] | undefined
-
-      if (this.rangeMode) {
-        valueToSet = [...this.selectedDates]
-      } else {
-        valueToSet =
-          this.selectedDates.length > 0 ? [this.selectedDates[0]] : undefined
-      }
-
-      this.ionDatetimeValue = valueToSet
-    }, 0)
+    this.scheduleIonDatetimeValue(() => this.getDeferredIonValue())
   }
 
   @Watch('value')
@@ -183,19 +199,7 @@ export class AtomDatetime {
       this.selectedDates = []
     }
 
-    // WORKAROUND: See explanation in componentWillLoad. Applied on prop changes too.
-    setTimeout(() => {
-      let valueToSet: string[] | undefined
-
-      if (this.rangeMode) {
-        valueToSet = [...this.selectedDates]
-      } else {
-        valueToSet =
-          this.selectedDates.length > 0 ? [this.selectedDates[0]] : undefined
-      }
-
-      this.ionDatetimeValue = valueToSet
-    }, 0)
+    this.scheduleIonDatetimeValue(() => this.getDeferredIonValue())
   }
 
   private handleRangeModeWithZeroDates() {
@@ -243,10 +247,7 @@ export class AtomDatetime {
     this.selectedDates = [...this.selectedDates]
     this.atomChange.emit(this.selectedDates)
 
-    // WORKAROUND: See explanation in componentWillLoad. Applied after user range selection.
-    setTimeout(() => {
-      this.ionDatetimeValue = [...this.selectedDates]
-    }, 0)
+    this.scheduleIonDatetimeValue(() => [...this.selectedDates])
   }
 
   handleDateChange = (event: CustomEvent<DatetimeChangeEventDetail>) => {
@@ -272,10 +273,7 @@ export class AtomDatetime {
       this.selectedDates = dates
       this.atomChange.emit(this.selectedDates)
 
-      // WORKAROUND: See explanation in componentWillLoad. Applied on prop changes too.
-      setTimeout(() => {
-        this.ionDatetimeValue = [...this.selectedDates]
-      }, 0)
+      this.scheduleIonDatetimeValue(() => [...this.selectedDates])
 
       return
     }
@@ -284,10 +282,9 @@ export class AtomDatetime {
 
     this.atomChange.emit(singleValue)
 
-    // WORKAROUND: See explanation in componentWillLoad. Applied on prop changes too.
-    setTimeout(() => {
-      this.ionDatetimeValue = singleValue ? [singleValue] : undefined
-    }, 0)
+    this.scheduleIonDatetimeValue(() =>
+      singleValue ? [singleValue] : undefined
+    )
   }
 
   private readonly handleBlur = () => {

--- a/packages/core/src/components/datetime/datetime.tsx
+++ b/packages/core/src/components/datetime/datetime.tsx
@@ -375,9 +375,7 @@ export class AtomDatetime {
   }
 
   private readCalendarDayIsoDate(day: HTMLElement): string | null {
-    const year = day.getAttribute('data-year')
-    const month = day.getAttribute('data-month')
-    const dayOfMonth = day.getAttribute('data-day')
+    const { year, month, day: dayOfMonth } = day.dataset
 
     if (!year || !month || !dayOfMonth) return null
 
@@ -389,7 +387,7 @@ export class AtomDatetime {
   ): string[] | null {
     if (selectedDates.length < 2) return null
 
-    const sortedDates = [...selectedDates].sort()
+    const sortedDates = [...selectedDates].sort((a, b) => a.localeCompare(b))
     const filledRange = this.calculateDateRange([
       sortedDates[0],
       sortedDates[sortedDates.length - 1],

--- a/packages/core/src/components/datetime/datetime.tsx
+++ b/packages/core/src/components/datetime/datetime.tsx
@@ -89,12 +89,43 @@ export class AtomDatetime {
   private _datetimeEl!: HTMLIonDatetimeElement
   private deferredValueTimeout?: ReturnType<typeof setTimeout>
 
+  private readonly handleRangeFillClick = (event: Event) => {
+    const clickedCalendarDay = event
+      .composedPath()
+      .some(
+        (target) =>
+          target instanceof HTMLElement &&
+          target.classList.contains('calendar-day')
+      )
+
+    if (!clickedCalendarDay) return
+
+    // With default buttons, ion-datetime defers ionChange until "Confirmar", so
+    // handleRangeMode never runs while the calendar is open and only the two
+    // endpoints stay highlighted. Re-apply the contiguous range after
+    // ion-datetime repaints the clicked day (double rAF) so the days in between
+    // highlight live.
+    requestAnimationFrame(() =>
+      requestAnimationFrame(() => this.fillVisibleRange())
+    )
+  }
+
   get datetimeEl(): HTMLIonDatetimeElement {
     return this._datetimeEl
   }
 
   set datetimeEl(value: HTMLIonDatetimeElement) {
+    if (this._datetimeEl === value) return
+
+    if (this._datetimeEl) {
+      this._datetimeEl.removeEventListener('click', this.handleRangeFillClick)
+    }
+
     this._datetimeEl = value
+
+    if (this.rangeMode && value) {
+      value.addEventListener('click', this.handleRangeFillClick)
+    }
   }
 
   private filterEmptyStrings(arr: string[]): string[] | undefined {
@@ -170,6 +201,10 @@ export class AtomDatetime {
   disconnectedCallback() {
     if (this.deferredValueTimeout) {
       clearTimeout(this.deferredValueTimeout)
+    }
+
+    if (this._datetimeEl) {
+      this._datetimeEl.removeEventListener('click', this.handleRangeFillClick)
     }
   }
 
@@ -337,6 +372,58 @@ export class AtomDatetime {
     const day = date.getDate().toString().padStart(2, '0')
 
     return `${year}-${month}-${day}`
+  }
+
+  private readCalendarDayIsoDate(day: HTMLElement): string | null {
+    const year = day.getAttribute('data-year')
+    const month = day.getAttribute('data-month')
+    const dayOfMonth = day.getAttribute('data-day')
+
+    if (!year || !month || !dayOfMonth) return null
+
+    return `${year}-${month.padStart(2, '0')}-${dayOfMonth.padStart(2, '0')}`
+  }
+
+  private getFilledRangeFromSelection(
+    selectedDates: string[]
+  ): string[] | null {
+    if (selectedDates.length < 2) return null
+
+    const sortedDates = [...selectedDates].sort()
+    const filledRange = this.calculateDateRange([
+      sortedDates[0],
+      sortedDates[sortedDates.length - 1],
+    ])
+
+    // The visible selection is already contiguous; re-applying it would loop the
+    // render with no change.
+    if (filledRange.length === selectedDates.length) return null
+
+    return filledRange
+  }
+
+  private fillVisibleRange() {
+    if (!this.rangeMode || !this._datetimeEl) return
+
+    const calendarRoot = this._datetimeEl.shadowRoot
+
+    if (!calendarRoot) return
+
+    const activeDays = Array.from(
+      calendarRoot.querySelectorAll<HTMLElement>(
+        '[part~="calendar-day"][part~="active"]'
+      )
+    )
+
+    const selectedDates = activeDays
+      .map((day) => this.readCalendarDayIsoDate(day))
+      .filter((date): date is string => date !== null)
+
+    const filledRange = this.getFilledRangeFromSelection(selectedDates)
+
+    if (filledRange) {
+      this.ionDatetimeValue = filledRange
+    }
   }
 
   private getRangeLabel(): string | null {

--- a/packages/core/src/components/datetime/datetime.tsx
+++ b/packages/core/src/components/datetime/datetime.tsx
@@ -226,7 +226,8 @@ export class AtomDatetime {
 
   private handleRangeMode(dates: string[]) {
     const sortedDates = [...dates].sort(
-      (a, b) => new Date(a).getTime() - new Date(b).getTime()
+      (a, b) =>
+        this.parseLocalDate(a).getTime() - this.parseLocalDate(b).getTime()
     )
 
     if (sortedDates.length === 0) {
@@ -345,7 +346,8 @@ export class AtomDatetime {
     if (!this.rangeMode || this.selectedDates.length < 2) return null
 
     const sortedSelectedDates = [...this.selectedDates].sort(
-      (a, b) => new Date(a).getTime() - new Date(b).getTime()
+      (a, b) =>
+        this.parseLocalDate(a).getTime() - this.parseLocalDate(b).getTime()
     )
     const [start, end] = [
       sortedSelectedDates[0],

--- a/packages/core/src/components/datetime/stories/datetime.core.stories.tsx
+++ b/packages/core/src/components/datetime/stories/datetime.core.stories.tsx
@@ -186,6 +186,30 @@ export const RangeModeWithDefaultDatesAndButton: StoryObj = {
   },
 }
 
+export const RangeModeWithButtonAndDefaultButtons: StoryObj = {
+  render: () => html`
+    <atom-datetime
+      range-mode
+      use-button="true"
+      show-default-buttons="true"
+      label="Selecionar período"
+      datetime-id="datetime-range-with-default-buttons"
+      cancel-text="Cancelar"
+      clear-text="Limpar"
+      done-text="Confirmar"
+      locale="pt-BR"
+    ></atom-datetime>
+  `,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Range mode with the button interface and the default Cancelar/Limpar/Confirmar buttons. While the calendar is open, selecting a start and end date highlights every day in between, even though ion-datetime only emits its value on "Confirmar".',
+      },
+    },
+  },
+}
+
 export const RangeModeWithMinMax: StoryObj = {
   render: () => html`
     <atom-datetime


### PR DESCRIPTION
## Problem

In range mode with the button interface and default buttons (`use-button` + `show-default-buttons`), selecting a start and end date showed only the two endpoints as separate circles. The days in between were not highlighted while the calendar was open. The value emitted on "Confirmar" and the button label were already correct; only the live calendar visual was wrong.

## Root cause

When `ion-datetime` renders the default Cancelar/Limpar/Confirmar buttons, it defers `ionChange` until the user confirms. `atom-datetime` expands a range into its contiguous days inside `handleRangeMode`, which only runs on `ionChange`. So during live selection the expansion never happened and only the raw endpoints stayed highlighted. (The inline range story works because, without buttons, `ionChange` fires on every day click.)

There is no public live event before confirm (`ionValueChange` does not fire either), so the only signal available during selection is the day click itself.

## What changed

Commits are atomic:

1. **`refactor(datetime): stop reflecting non-primitive value prop`** — `value` is a `string[] | object`; reflecting it to an attribute serialized oddly. Reflection removed.
2. **`fix(datetime): sort range dates with local parsing to avoid tz drift`** — the two sort comparators now use `parseLocalDate` instead of `new Date(iso)` (UTC), consistent with the rest of the date math.
3. **`fix(datetime): cancel deferred value timers on disconnect`** — the four `setTimeout(0)` value-deferral workarounds are centralized into one tracked `scheduleIonDatetimeValue` and cancelled in `disconnectedCallback`, so a pending timer never resolves against an unmounted component.
4. **`fix(datetime): fill date range while calendar open with default buttons`** — on each calendar-day click, after `ion-datetime` repaints (double `requestAnimationFrame`), read the active days and re-apply the contiguous range so the in-between days highlight live. A contiguity guard avoids redundant re-renders, and the click listener is removed on disconnect.

A new Storybook story `RangeModeWithButtonAndDefaultButtons` reproduces the app configuration that previously had no coverage.

## Testing

- 40 unit tests pass (10 new), snapshots unchanged, `stencil build` clean, ESLint clean.
- Verified end to end in Storybook: live range fill works with confirm buttons, "Confirmar" emits the full range, the label is correct, the preset-value range story still renders, and inline range mode is unregressed.
- Verified in the consuming app via a local build: selecting a range now fills all days in between live.
 
🤖 Generated with [Claude Code](https://claude.com/claude-code)
