### PR TITLE
fix(datetime): re-sync calendar view on reopen to stop month jump

### DIFF
--- a/packages/core/src/components/datetime/datetime.spec.ts
+++ b/packages/core/src/components/datetime/datetime.spec.ts
@@ -777,4 +777,64 @@ describe('AtomDatetime', () => {
       expect(datetime.ionDatetimeValue).toEqual(['initial'])
     })
   })
+
+  describe('re-syncs the calendar view when the popover reopens', () => {
+    const buildRangeModePage = async () =>
+      newSpecPage({
+        components: [AtomDatetime],
+        html: '<atom-datetime use-button="true" range-mode="true"></atom-datetime>',
+      })
+
+    it('resets ion-datetime when the popover presents', async () => {
+      const page = await buildRangeModePage()
+      const datetime = page.rootInstance
+      const reset = jest.fn().mockResolvedValue(undefined)
+
+      datetime._datetimeEl = { reset }
+      datetime.handlePopoverPresent()
+
+      expect(reset).toHaveBeenCalled()
+    })
+
+    it('does nothing on present when there is no datetime element', async () => {
+      const page = await buildRangeModePage()
+      const datetime = page.rootInstance
+
+      datetime._datetimeEl = undefined
+
+      expect(() => datetime.handlePopoverPresent()).not.toThrow()
+    })
+
+    it('attaches the present listener to the popover only once', async () => {
+      const page = await buildRangeModePage()
+      const datetime = page.rootInstance
+      const popover = { addEventListener: jest.fn() }
+
+      datetime.setupPopover(popover)
+      datetime.setupPopover(popover)
+
+      expect(popover.addEventListener).toHaveBeenCalledTimes(1)
+      expect(popover.addEventListener).toHaveBeenCalledWith(
+        'ionDidPresent',
+        expect.any(Function)
+      )
+    })
+
+    it('removes the present listener on disconnect', async () => {
+      const page = await buildRangeModePage()
+      const datetime = page.rootInstance
+      const popover = {
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+      }
+
+      datetime.setupPopover(popover)
+      datetime.disconnectedCallback()
+
+      expect(popover.removeEventListener).toHaveBeenCalledWith(
+        'ionDidPresent',
+        expect.any(Function)
+      )
+    })
+  })
 })

--- a/packages/core/src/components/datetime/datetime.tsx
+++ b/packages/core/src/components/datetime/datetime.tsx
@@ -87,7 +87,26 @@ export class AtomDatetime {
   @Event() atomCancel!: EventEmitter<void>
 
   private _datetimeEl!: HTMLIonDatetimeElement
+  private popoverEl?: HTMLElement
   private deferredValueTimeout?: ReturnType<typeof setTimeout>
+
+  private readonly setupPopover = (popover: HTMLElement | undefined) => {
+    if (!popover || this.popoverEl === popover) return
+
+    this.popoverEl = popover
+    popover.addEventListener('ionDidPresent', this.handlePopoverPresent)
+  }
+
+  private readonly handlePopoverPresent = () => {
+    if (!this._datetimeEl) return
+
+    // After switching browser tabs and back, the kept-mounted ion-datetime can
+    // desync its rendered calendar grid from its header — clicking a visible day
+    // then registers a different month. reset() re-renders the view to the
+    // current value's month (without changing the value), re-syncing grid and
+    // header so clicks land on the day the user sees.
+    this._datetimeEl.reset().catch(() => undefined)
+  }
 
   private readonly handleRangeFillClick = (event: Event) => {
     const clickedCalendarDay = event
@@ -205,6 +224,13 @@ export class AtomDatetime {
 
     if (this._datetimeEl) {
       this._datetimeEl.removeEventListener('click', this.handleRangeFillClick)
+    }
+
+    if (this.popoverEl) {
+      this.popoverEl.removeEventListener(
+        'ionDidPresent',
+        this.handlePopoverPresent
+      )
     }
   }
 
@@ -556,6 +582,7 @@ export class AtomDatetime {
           />
         </div>
         <ion-popover
+          ref={(el) => this.setupPopover(el)}
           keep-contents-mounted='true'
           show-backdrop='false'
           style={{ 'margin-top': '1px' }}


### PR DESCRIPTION
## Problem

In range mode with the button interface, after this sequence the picker misbehaves:

1. Open the picker, select a date, close it.
2. Switch to another browser tab, then return.
3. Reopen the picker and click a day.

The clicked day registers under the **wrong month** and a large, unintended cross-month range gets selected.

## Root cause

`atom-datetime` renders `ion-datetime` inside an `ion-popover` with `keep-contents-mounted="true"`, so the calendar stays mounted (but hidden) when closed. ion-datetime tracks the visible month via a scroll position + IntersectionObserver. When the tab loses and regains visibility while the calendar is hidden, that tracking desyncs: the **rendered grid no longer matches the header**. Clicking a cell that visually reads as e.g. "June 9" then registers a May date, and the header snaps to May.

Captured with diagnostics in the consuming app:

```
CLICK — day: 2026-05-05 | month BEFORE: junho de 2026 | active BEFORE: ["2026-06-09"]
FILL  — month AFTER:  maio de 2026 | active AFTER: ["2026-05-05","2026-06-09"]
```

The day clicked under a "June" header registered as `2026-05-05`, confirming the grid/header desync. (The range fill then faithfully fills between the two registered dates, which is why the visible damage is a giant range.)

## Fix

On every popover present (`ionDidPresent`), call `ion-datetime.reset()`, which re-renders the calendar view to the current value's month **without changing the value**. This re-syncs grid and header before the user interacts, so clicks land on the day shown. It also discards any stale uncommitted working selection from a previous open. The listener is cleaned up in `disconnectedCallback`.

## Testing

- 48 unit tests pass (4 new: present resets the datetime, no-op without a datetime element, listener attached once, listener removed on disconnect). Snapshots unchanged, `stencil build` and ESLint clean.
- Verified in the consuming app via a local build: the open → close → tab-switch → reopen → click flow now registers the correct day with no month jump, and normal range selection / committed-value display are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
