### PR TITLE
fix(react): add explicit extension to esm entry re-export

### DIFF
--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,1 +1,1 @@
-export * from './components/components'
+export * from './components/components.js'


### PR DESCRIPTION
## What

One-line fix: `packages/react/src/index.ts` re-exported `'./components/components'` without the `.js` extension. The emitted `react/dist/index.js` kept it extensionless, which bundlers resolve but **Node's native ESM loader does not**.

## Why

Next.js (pages router) externalizes `node_modules` in the server build, so Node imports `@juntossomosmais/atomium/react` directly during "Collecting page data" and fails:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../react/dist/components/components'
imported from .../react/dist/index.js
```

This breaks `next build` for any SSR consumer. worked around it with `transpilePackages: ['@juntossomosmais/atomium']`; misty-mountains (also Next) would hit the same failure.

All the **generated** wrapper files already use explicit `.js` extensions (the output target emits them correctly); this was the only hand-written import missing one.

## Verification

- `tsc -p packages/react` compiles cleanly with the extension (moduleResolution `Bundler` resolves `.js` → `.ts`)
- Emitted `core/react/dist/index.js` now reads `export * from './components/components.js'`
- Plain Node (no bundler): `import('react/dist/index.js')` loads all 28 component exports, exercising the full chain (wrappers → `@stencil/react-output-target/runtime` → `dist/components` custom elements → react)

## Known caveat (out of scope)

Node prints a module-format detection warning for `dist/components/*.js` because core's `package.json` has no `type` field (the published `react/package.json` stub declares `"type": "module"`, but the `dist/components` files resolve under core scope). Node ≥20.19/22 auto-detects ESM so everything loads; older minors would not. If we want to silence the warnings and support older Node, a follow-up could emit a `{"type":"module"}` stub into `dist/components/` at build time. Flipping `"type": "module"` on core root is NOT safe as-is (`dist/index.cjs.js` ends in `.js` and would be reparsed as ESM for `require` consumers).

## Consumer impact

After this ships, can drop `transpilePackages: ['@juntossomosmais/atomium']` (keeping it is also harmless), and misty-mountains can bump without the workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)