### PR TITLE
ci(repo): modernize deprecated actions in ci workflows

### DIFF
--- a/.github/workflows/ghpages.yml
+++ b/.github/workflows/ghpages.yml
@@ -22,8 +22,6 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
@@ -34,6 +32,14 @@ jobs:
           node-version: 22
           cache: 'pnpm'
           registry-url: 'https://npm.pkg.github.com'
+
+      - name: Restore Nx cache
+        uses: actions/cache@v5
+        with:
+          path: .nx/cache
+          key: nx-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            nx-${{ runner.os }}-
 
       - name: Install dependencies 🔧
         run: |

--- a/.github/workflows/icons.yml
+++ b/.github/workflows/icons.yml
@@ -23,8 +23,6 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -40,6 +40,14 @@ jobs:
           cache: 'pnpm'
           registry-url: 'https://npm.pkg.github.com'
 
+      - name: Restore Nx cache
+        uses: actions/cache@v5
+        with:
+          path: .nx/cache
+          key: nx-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            nx-${{ runner.os }}-
+
       - name: Install dependencies 🔧
         run: |
           echo "@juntossomosmais:registry=https://npm.pkg.github.com" >> .npmrc

--- a/.github/workflows/release-and-publish-packages.yml
+++ b/.github/workflows/release-and-publish-packages.yml
@@ -20,26 +20,24 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: google-github-actions/release-please-action@v3
+      # release-type and monorepo tagging are configured in release-please-config.json
+      - uses: googleapis/release-please-action@v5
         with:
-          release-type: node
-          command: manifest
-          monorepo-tags: true
           token: ${{ secrets.GITHUB_TOKEN }}
         id: release
 
       - name: Checkout Repository
-        if: ${{ steps.release.outputs.releases_created }}
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
         uses: actions/checkout@v6
         with:
           ref: main
 
       - name: Setup pnpm
-        if: ${{ steps.release.outputs.releases_created }}
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
         uses: pnpm/action-setup@v6
 
       - name: Setup Node
-        if: ${{ steps.release.outputs.releases_created }}
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
         uses: actions/setup-node@v6
         with:
           node-version: 22
@@ -48,20 +46,20 @@ jobs:
           scope: '@juntossomosmais'
 
       - name: Authenticate with the GitHub Package Registry and Install dependencies
-        if: ${{ steps.release.outputs.releases_created }}
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
         run: |
           echo "@juntossomosmais:registry=https://npm.pkg.github.com" >> .npmrc
           echo "//npm.pkg.github.com/:_authToken=${{ secrets.GH_ACTIONS }}" >> .npmrc
           pnpm install --frozen-lockfile
 
       - name: Build and publish Core
-        if: ${{ steps.release.outputs['packages/core--release_created'] }}
+        if: ${{ steps.release.outputs['packages/core--release_created'] == 'true' }}
         run: pnpm exec nx run @juntossomosmais/atomium:publish-library
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and publish Tokens
-        if: ${{ steps.release.outputs['packages/tokens--release_created'] }}
+        if: ${{ steps.release.outputs['packages/tokens--release_created'] == 'true' }}
         run: pnpm exec nx run @juntossomosmais/atomium-tokens:publish-library
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sonarcloud-scan.yml
+++ b/.github/workflows/sonarcloud-scan.yml
@@ -79,18 +79,16 @@ jobs:
 
       - name: SonarCloud Scan - Core 🚨
         if: env.COVERAGE_CORE == 'true'
-        uses: sonarsource/sonarcloud-github-action@master
+        uses: SonarSource/sonarqube-scan-action@v8
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
           projectBaseDir: packages/core/
 
       - name: SonarCloud Scan - Tokens 🚨
         if: env.COVERAGE_TOKENS == 'true'
-        uses: sonarsource/sonarcloud-github-action@master
+        uses: SonarSource/sonarqube-scan-action@v8
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
           projectBaseDir: .

--- a/.github/workflows/sonarcloud-scan.yml
+++ b/.github/workflows/sonarcloud-scan.yml
@@ -47,6 +47,14 @@ jobs:
           cache: 'pnpm'
           registry-url: 'https://npm.pkg.github.com'
 
+      - name: Restore Nx cache
+        uses: actions/cache@v5
+        with:
+          path: .nx/cache
+          key: nx-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            nx-${{ runner.os }}-
+
       - name: Install dependencies 🔧
         run: |
           echo "@juntossomosmais:registry=https://npm.pkg.github.com" >> .npmrc

--- a/apps/docs-react/package.json
+++ b/apps/docs-react/package.json
@@ -14,7 +14,16 @@
               "@juntossomosmais/atomium-react"
             ],
             "target": "build"
+          },
+          {
+            "projects": [
+              "@atomium/docs"
+            ],
+            "target": "build"
           }
+        ],
+        "outputs": [
+          "{workspaceRoot}/apps/docs/storybook-static/react"
         ]
       }
     }

--- a/apps/docs-vue/package.json
+++ b/apps/docs-vue/package.json
@@ -14,7 +14,16 @@
               "@juntossomosmais/atomium-vue"
             ],
             "target": "build"
+          },
+          {
+            "projects": [
+              "@atomium/docs"
+            ],
+            "target": "build"
           }
+        ],
+        "outputs": [
+          "{workspaceRoot}/apps/docs/storybook-static/vue"
         ]
       }
     }

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -17,6 +17,9 @@
             ],
             "target": "build"
           }
+        ],
+        "outputs": [
+          "{projectRoot}/storybook-static"
         ]
       }
     }

--- a/nx.json
+++ b/nx.json
@@ -18,6 +18,10 @@
     },
     "test": {
       "cache": true
+    },
+    "test:ci": {
+      "cache": true,
+      "outputs": ["{projectRoot}/coverage"]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "preinstall": "npx only-allow pnpm",
     "build": "nx build @juntossomosmais/atomium && nx build @juntossomosmais/atomium-react && nx build @juntossomosmais/atomium-vue",
-    "docs:build": "pnpm run build && nx build @atomium/docs && nx build @atomium/docs-react && nx build @atomium/docs-vue",
+    "docs:build": "nx run-many --target=build --projects=@atomium/docs,@atomium/docs-react,@atomium/docs-vue",
     "docs-react:start": "nx run @atomium/docs-react:start",
     "docs-vue:start": "nx run @atomium/docs-vue:start",
     "icons:build": "nx build @juntossomosmais/atomium-icons",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -97,6 +97,14 @@
             ],
             "target": "build"
           }
+        ],
+        "outputs": [
+          "{projectRoot}/dist",
+          "{projectRoot}/loader",
+          "{projectRoot}/core.css",
+          "{projectRoot}/src/components.d.ts",
+          "{workspaceRoot}/packages/react/src/components",
+          "{workspaceRoot}/packages/vue/src/components/index.ts"
         ]
       },
       "start": {

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -19,6 +19,11 @@
       "build": {
         "dependsOn": [
           "build:scripts"
+        ],
+        "outputs": [
+          "{projectRoot}/dist",
+          "{projectRoot}/index.ts",
+          "{workspaceRoot}/packages/core/src/icons.d.ts"
         ]
       }
     }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -25,6 +25,9 @@
             ],
             "target": "build"
           }
+        ],
+        "outputs": [
+          "{workspaceRoot}/packages/core/react"
         ]
       },
       "start": {

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -43,6 +43,10 @@
       "build": {
         "dependsOn": [
           "build:css"
+        ],
+        "outputs": [
+          "{projectRoot}/dist",
+          "{projectRoot}/index.ts"
         ]
       },
       "publish-library": {

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -23,6 +23,9 @@
             ],
             "target": "build"
           }
+        ],
+        "outputs": [
+          "{workspaceRoot}/packages/core/vue"
         ]
       },
       "start": {

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,7 @@
 {
   "last-release-sha": "efb44bdfe1cd1fe8d5c29c3065140d45ee9ddb44",
+  "release-type": "node",
+  "include-component-in-tag": true,
   "packages": {
     "packages/core": {},
     "packages/tokens": {}


### PR DESCRIPTION
## Summary

### release-please: `google-github-actions/release-please-action@v3` → `googleapis/release-please-action@v5`

- The `command: manifest` and `monorepo-tags` inputs were removed in v4+; manifest mode is now the default and config lives in `release-please-config.json`
- `release-type: node` moved from action input to the config file
- `include-component-in-tag: true` set explicitly in the config: the default changed to `false` in v4, which would have broken the existing `atomium-vX.Y.Z` / `atomium-tokens-vX.Y.Z` tag scheme
- Publish conditions changed from truthy checks to `== 'true'`: v4+ always sets outputs as strings, so `if: ${{ outputs.releases_created }}` would be truthy even when the value is `'false'` and publish steps would run on every push
- Kept `GITHUB_TOKEN`: the PAT recommendation in the docs only applies if CI checks must trigger on release PRs, which matches the current v3 behavior (no change)

### SonarCloud: `sonarsource/sonarcloud-github-action@master` → `SonarSource/sonarqube-scan-action@v8`

- The sonarcloud action was deprecated and merged into `sonarqube-scan-action`
- `projectBaseDir` and `args` inputs are unchanged
- `GITHUB_TOKEN` env dropped: the new action only needs `SONAR_TOKEN` for SonarQube Cloud (PR info comes from the Actions context)

### Audit of remaining workflows

All other actions already pinned to current majors: `actions/checkout@v6`, `actions/setup-node@v6`, `pnpm/action-setup@v6`, `aws-actions/configure-aws-credentials@v5`, `JamesIves/github-pages-deploy-action@v4` (latest v4.8.0), `rossjrw/pr-preview-action@v1` (latest v1.8.1).

### Pipeline performance

- **Nx computation cache persisted across CI runs**: `actions/cache@v5` on `.nx/cache` in the ghpages, preview, and sonar workflows. Prerequisite for safe cache replays: `outputs` declared on every build target, including off-`dist` artifacts (`packages/core/loader`, `core.css`, the react/vue wrappers written into `packages/core/`, generated `index.ts` of tokens/icons, `storybook-static`). Release and CDN deploy workflows intentionally stay uncached so publish paths always build fresh.
- **`docs:build` parallelized**: from 6 sequential `nx build` calls chained with `&&` to a single `nx run-many` respecting the task graph. The react/vue storybooks gained an explicit dependency on the root storybook because `storybook build` wipes `storybook-static/` and would clobber their output subdirs if it ran after them.
- **`test:ci` is now cacheable** with `coverage/` declared as output, keeping the Sonar coverage gate working on cache replays.
- **Shallow clones** in ghpages and icons (`fetch-depth: 0` removed; only Sonar needs full history for blame and `nx affected`).

## Validation

- All workflow YAML parses cleanly
- Config keys (`release-type`, `include-component-in-tag`, `last-release-sha`) validated against the release-please config schema
- `release-please@17.6.0` (exact version bundled in action v5) dry-run against this branch: resolves components `atomium`/`atomium-tokens`, finds current releases core 4.1.4 / tokens 2.1.2, and correctly reports nothing to release (only `ci:` commits)
- Full local `docs:build` with the new parallel graph: 3 storybooks + 7 dependency tasks built in the correct order, `storybook-static/` complete with root + `react/` + `vue/`
- The `nx.json` change marks all projects affected, so this PR runs the full test suite and both Sonar scans, validating the new scan action end-to-end

## Test plan

- [ ] SonarCloud scan runs and decorates this PR for core/tokens
- [ ] After merge: release-please opens the release PR with correct versions and tags
- [ ] After merging a release PR: core/tokens publish to GitHub Packages successfully
- [ ] After merge: ghpages run saves the Nx cache; a follow-up PR restores it (check "Restore Nx cache" step output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)