### PR TITLE
feat(core): add disable close button option to modal

### DIFF
--- a/packages/core/src/components/modal/modal.spec.ts
+++ b/packages/core/src/components/modal/modal.spec.ts
@@ -160,6 +160,45 @@ describe('atom-modal', () => {
     expect(spySecondary).toHaveBeenCalled()
   })
 
+  it('should render the close button as disabled when disableCloseButton is true', async () => {
+    page = await newSpecPage({
+      components: [AtomModal],
+      html: `
+      <atom-modal is-open="true" disable-close-button="true">
+        Modal content
+      </atom-modal>
+    `,
+    })
+
+    const closeButton = page.root?.querySelector('.atom-modal__close')
+
+    expect(closeButton?.hasAttribute('disabled')).toBe(true)
+  })
+
+  it('should not emit atomCloseClick nor dismiss when disableCloseButton is true', async () => {
+    page = await newSpecPage({
+      components: [AtomModal],
+      html: `
+      <atom-modal is-open="true" disable-close-button="true">
+        Modal content
+      </atom-modal>
+    `,
+    })
+
+    const dismiss = jest.fn()
+    const spyClose = jest.fn()
+
+    page.rootInstance.modal = { dismiss, close: jest.fn() }
+    page.root?.addEventListener('atomCloseClick', spyClose)
+
+    const closeButton = page.root?.querySelector('.atom-modal__close')
+
+    closeButton?.dispatchEvent(new Event('click'))
+
+    expect(spyClose).not.toHaveBeenCalled()
+    expect(dismiss).not.toHaveBeenCalled()
+  })
+
   it('should render progress bar when progress is passed even if it is zero', async () => {
     await page.setContent(`
       <atom-modal>

--- a/packages/core/src/components/modal/modal.tsx
+++ b/packages/core/src/components/modal/modal.tsx
@@ -34,6 +34,7 @@ export class AtomModal {
   @Prop() hasFooter = true
   @Prop() disablePrimaryButton = false
   @Prop() disableSecondaryButton = false
+  @Prop() disableCloseButton = false
   @Prop({ mutable: true }) isOpen = false
   @Prop({ mutable: true }) canDismiss?: boolean
   @Prop() metaData?: MetaData = {}
@@ -74,6 +75,10 @@ export class AtomModal {
   }
 
   private readonly handleCloseClick = async () => {
+    if (this.disableCloseButton) {
+      return
+    }
+
     this.atomCloseClick.emit(this.modal)
     this.modal.dismiss()
   }
@@ -129,6 +134,7 @@ export class AtomModal {
               color='secondary'
               fill='clear'
               shape='circle'
+              disabled={this.disableCloseButton}
               onClick={this.handleCloseClick}
               aria-label='close'
               class='atom-modal__close'

--- a/packages/core/src/components/modal/stories/modal.args.ts
+++ b/packages/core/src/components/modal/stories/modal.args.ts
@@ -109,6 +109,14 @@ export const ModalStoryArgs = {
         category: Category.PROPERTIES,
       },
     },
+    disableCloseButton: {
+      control: 'boolean',
+      description:
+        'If true, the close button will be disabled. Default is false',
+      table: {
+        category: Category.PROPERTIES,
+      },
+    },
     canDismiss: {
       control: 'boolean',
       description:
@@ -247,6 +255,7 @@ export const ModalComponentArgs = {
   hasDivider: false,
   disableSecondaryButton: false,
   disablePrimaryButton: false,
+  disableCloseButton: false,
   isOpen: false,
   canDismiss: true,
 }


### PR DESCRIPTION
[Task](https://juntossomosmais.monday.com/boards/5143488854/views/113762127/pulses/12169528213?userId=30945655)

## Summary

Adds a new `disableCloseButton` prop to the `atom-modal` component. When set to `true`:

- The modal's close button is rendered in a `disabled` state.
- Clicking the close button no longer emits the `atomCloseClick` event nor dismisses the modal (the `handleCloseClick` handler returns early).

The prop defaults to `false`, so existing behavior is unchanged. The new option is also exposed in the Storybook controls/args under the component properties category.

Covered by two new unit tests:
- Verifies the close button renders with the `disabled` attribute when `disableCloseButton` is `true`.
- Verifies `atomCloseClick` is not emitted and `dismiss()` is not called on click when `disableCloseButton` is `true`.

## Evidences

_N/A — internal behavior/prop change. See unit tests and Storybook control for verification._

🤖 Generated with [Claude Code](https://claude.com/claude-code)