### PR TITLE
fix(react): restrict ssr barrel generator to atom-* wrappers

### DIFF
--- a/packages/react/scripts/generate-server-barrel.mjs
+++ b/packages/react/scripts/generate-server-barrel.mjs
@@ -34,8 +34,12 @@ const toPascalCase = (tag) =>
     .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
     .join('')
 
+// Only per-component wrappers follow the `atom-*` tag convention. Newer
+// versions of the React Output Target also emit a `components.server.ts`
+// barrel, which must be excluded so the toPascalCase heuristic does not emit
+// a bogus `export { Components }` for a member that does not exist.
 const serverFiles = readdirSync(componentsDir)
-  .filter((file) => file.endsWith('.server.ts'))
+  .filter((file) => file.startsWith('atom-') && file.endsWith('.server.ts'))
   .sort((a, b) => a.localeCompare(b))
 
 if (serverFiles.length === 0) {


### PR DESCRIPTION
## Problem

`nx build @juntossomosmais/atomium-react` fails on a clean build with:

```
src/index.server.ts:33:10 - error TS2305: Module '"./components/components.js"' has no exported member 'Components'.
```

This breaks the React package build and, by extension, `atomium:publish-library` (which `dependsOn` `atomium-react:build`). It is not caught by the PR gate because the Sonar workflow runs only `test:ci` (no build), so it has been latent on `main`.

## Root cause

`packages/react/src/index.server.ts` is generated by `scripts/generate-server-barrel.mjs`, which globs **every** `*.server.ts` file and derives an export name via `toPascalCase(tag)`. The Stencil React Output Target also emits a `components.server.ts` **barrel** file, so the generator turned `components` into `Components` and produced a bogus:

```ts
export { Components } from './components/components.js'
```

But the generated `components.ts` has no `Components` member, so `tsc` fails. The script's own doc already states it assumes the per-component `atom-*` tag convention — the barrel simply slipped through the filter.

## Fix

Restrict the glob to `atom-*.server.ts`, matching the documented convention and excluding the `components.server.ts` barrel.

## Verification

- `nx build @juntossomosmais/atomium-react` → **passes** (28 wrappers, no bogus export)
- `pnpm run build` (all packages) → green
- `pnpm run test:ci` → green
- Node 22 (CI runtime), pnpm 10.28.2, `--frozen-lockfile`
