### PR TITLE
chore(deps): bump production-dependencies group

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
     "tokens:build": "nx build @juntossomosmais/atomium-tokens"
   },
   "dependencies": {
-    "@ionic/core": "^8.8.5",
+    "@ionic/core": "^8.8.13",
     "@popperjs/core": "^2.11.8",
     "@stencil/core": "^4.43.5",
-    "dompurify": "^3.4.2"
+    "dompurify": "^3.4.11"
   },
   "devDependencies": {
     "@babel/core": "^7.29.7",
@@ -45,9 +45,9 @@
     "@juntossomosmais/rupture-scss": "^1.1.1",
     "@nx/workspace": "^22.7.5",
     "@rollup/plugin-typescript": "^12.3.0",
-    "@stencil/react-output-target": "^1.5.3",
+    "@stencil/react-output-target": "^1.6.0",
     "@stencil/sass": "^3.2.3",
-    "@stencil/vue-output-target": "^0.13.2",
+    "@stencil/vue-output-target": "^0.14.0",
     "@storybook/addon-a11y": "^10.4.6",
     "@storybook/addon-docs": "^10.4.6",
     "@storybook/react-vite": "^10.4.6",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -77,8 +77,8 @@
     }
   },
   "dependencies": {
-    "@stencil/react-output-target": "^1.5.3",
-    "@stencil/vue-output-target": "^0.13.2"
+    "@stencil/react-output-target": "^1.6.0",
+    "@stencil/vue-output-target": "^0.14.0"
   },
   "devDependencies": {
     "@atomium/scss-utils": "workspace:*",

--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -6,11 +6,11 @@
  */
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
 import { IconProps } from "./icons";
-import { DatetimeHighlight, DatetimeHighlightCallback, DatetimePresentation, Mode, TextFieldTypes } from "@ionic/core";
+import { DatetimeHighlight, DatetimeHighlightCallback, DatetimePresentation, FormatOptions, Mode, TextFieldTypes } from "@ionic/core";
 import { JSX as IonTypes } from "@ionic/core/dist/types/components";
 import { AtomModal } from "./components/modal/modal";
 export { IconProps } from "./icons";
-export { DatetimeHighlight, DatetimeHighlightCallback, DatetimePresentation, Mode, TextFieldTypes } from "@ionic/core";
+export { DatetimeHighlight, DatetimeHighlightCallback, DatetimePresentation, FormatOptions, Mode, TextFieldTypes } from "@ionic/core";
 export { JSX as IonTypes } from "@ionic/core/dist/types/components";
 export { AtomModal } from "./components/modal/modal";
 export namespace Components {
@@ -159,10 +159,7 @@ export namespace Components {
         /**
           * @default {     date: {       month: '2-digit',       day: '2-digit',       year: 'numeric',     },     time: {       hour: '2-digit',       minute: '2-digit',     },   }
          */
-        "formatOptions": {
-    date?: Intl.DateTimeFormatOptions
-    time?: Intl.DateTimeFormatOptions
-  };
+        "formatOptions": FormatOptions;
         "highlightedDates"?: DatetimeHighlight[] | DatetimeHighlightCallback;
         /**
           * @default 'h23'
@@ -1254,10 +1251,7 @@ declare namespace LocalJSX {
         /**
           * @default {     date: {       month: '2-digit',       day: '2-digit',       year: 'numeric',     },     time: {       hour: '2-digit',       minute: '2-digit',     },   }
          */
-        "formatOptions"?: {
-    date?: Intl.DateTimeFormatOptions
-    time?: Intl.DateTimeFormatOptions
-  };
+        "formatOptions"?: FormatOptions;
         "highlightedDates"?: DatetimeHighlight[] | DatetimeHighlightCallback;
         /**
           * @default 'h23'

--- a/packages/core/src/components/datetime/datetime.tsx
+++ b/packages/core/src/components/datetime/datetime.tsx
@@ -4,6 +4,7 @@ import {
   DatetimeHighlight,
   DatetimeHighlightCallback,
   DatetimePresentation,
+  FormatOptions,
 } from '@ionic/core'
 import {
   Component,
@@ -39,10 +40,7 @@ export class AtomDatetime {
   @Prop() dayValues?: number[] | string
   @Prop() disabled?: boolean
   @Prop() doneText?: string
-  @Prop() formatOptions: {
-    date?: Intl.DateTimeFormatOptions
-    time?: Intl.DateTimeFormatOptions
-  } = {
+  @Prop() formatOptions: FormatOptions = {
     date: {
       month: '2-digit',
       day: '2-digit',

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -43,7 +43,7 @@
     }
   },
   "dependencies": {
-    "@stencil/react-output-target": "^1.5.3"
+    "@stencil/react-output-target": "^1.6.0"
   },
   "devDependencies": {
     "@juntossomosmais/atomium": "workspace:*",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -43,7 +43,7 @@
     }
   },
   "dependencies": {
-    "@stencil/vue-output-target": "^0.13.2"
+    "@stencil/vue-output-target": "^0.14.0"
   },
   "devDependencies": {
     "@juntossomosmais/atomium": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,8 +23,8 @@ importers:
   .:
     dependencies:
       '@ionic/core':
-        specifier: ^8.8.5
-        version: 8.8.8
+        specifier: ^8.8.13
+        version: 8.8.13
       '@popperjs/core':
         specifier: ^2.11.8
         version: 2.11.8
@@ -32,8 +32,8 @@ importers:
         specifier: ^4.43.5
         version: 4.43.5
       dompurify:
-        specifier: ^3.4.2
-        version: 3.4.7
+        specifier: ^3.4.11
+        version: 3.4.11
     devDependencies:
       '@babel/core':
         specifier: ^7.29.7
@@ -72,14 +72,14 @@ importers:
         specifier: ^12.3.0
         version: 12.3.0(rollup@4.62.2)(tslib@2.8.1)(typescript@6.0.3)
       '@stencil/react-output-target':
-        specifier: ^1.5.3
-        version: 1.5.3(@stencil/core@4.43.5)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: ^1.6.0
+        version: 1.6.0(@stencil/core@4.43.5)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@stencil/sass':
         specifier: ^3.2.3
         version: 3.2.3(@stencil/core@4.43.5)
       '@stencil/vue-output-target':
-        specifier: ^0.13.2
-        version: 0.13.2(@stencil/core@4.43.5)(vue@3.5.39(typescript@6.0.3))
+        specifier: ^0.14.0
+        version: 0.14.0(@stencil/core@4.43.5)(vue@3.5.39(typescript@6.0.3))
       '@storybook/addon-a11y':
         specifier: ^10.4.6
         version: 10.4.6(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
@@ -297,11 +297,11 @@ importers:
   packages/core:
     dependencies:
       '@stencil/react-output-target':
-        specifier: ^1.5.3
-        version: 1.5.3(@stencil/core@4.43.5)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: ^1.6.0
+        version: 1.6.0(@stencil/core@4.43.5)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@stencil/vue-output-target':
-        specifier: ^0.13.2
-        version: 0.13.2(@stencil/core@4.43.5)(vue@3.5.35(typescript@6.0.3))
+        specifier: ^0.14.0
+        version: 0.14.0(@stencil/core@4.43.5)(vue@3.5.35(typescript@6.0.3))
       react:
         specifier: '>=18'
         version: 19.2.7
@@ -324,8 +324,8 @@ importers:
   packages/react:
     dependencies:
       '@stencil/react-output-target':
-        specifier: ^1.5.3
-        version: 1.5.3(@stencil/core@4.43.5)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: ^1.6.0
+        version: 1.6.0(@stencil/core@4.43.5)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     devDependencies:
       '@juntossomosmais/atomium':
         specifier: workspace:*
@@ -346,8 +346,8 @@ importers:
   packages/vue:
     dependencies:
       '@stencil/vue-output-target':
-        specifier: ^0.13.2
-        version: 0.13.2(@stencil/core@4.43.5)(vue@3.5.39(typescript@6.0.3))
+        specifier: ^0.14.0
+        version: 0.14.0(@stencil/core@4.43.5)(vue@3.5.39(typescript@6.0.3))
     devDependencies:
       '@juntossomosmais/atomium':
         specifier: workspace:*
@@ -1398,8 +1398,8 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
-  '@ionic/core@8.8.8':
-    resolution: {integrity: sha512-GGvYtEzLtn1gBUC1/vb4pvA3gQzYskTNVIsvdTVIgnwLtdt70rwTibrZRSqmkyHeqpjg/u3+9XsM2c0kzc/V3w==}
+  '@ionic/core@8.8.13':
+    resolution: {integrity: sha512-f09pRxmOLxPvLeCK9kTTBiByaPeCrApwABAwkqeax08e1b4kDSyXD1nMGDT6ChTvUGxyt4/cPxLsEP68ku4+HQ==}
     engines: {node: '>= 16'}
 
   '@istanbuljs/load-nyc-config@1.1.0':
@@ -2138,11 +2138,6 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.34.9':
-    resolution: {integrity: sha512-0CY3/K54slrzLDjOA7TOjN1NuLKERBgk9nY5V34mhmuu673YNb+7ghaDUs6N0ujXR7fz5XaS5Aa6d2TNxZd0OQ==}
-    cpu: [arm64]
-    os: [darwin]
-
   '@rollup/rollup-darwin-arm64@4.44.0':
     resolution: {integrity: sha512-VGF3wy0Eq1gcEIkSCr8Ke03CWT+Pm2yveKLaDvq51pPpZza3JX/ClxXOCmTYYq3us5MvEuNRTaeyFThCKRQhOA==}
     cpu: [arm64]
@@ -2151,11 +2146,6 @@ packages:
   '@rollup/rollup-darwin-arm64@4.62.2':
     resolution: {integrity: sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==}
     cpu: [arm64]
-    os: [darwin]
-
-  '@rollup/rollup-darwin-x64@4.34.9':
-    resolution: {integrity: sha512-eOojSEAi/acnsJVYRxnMkPFqcxSMFfrw7r2iD9Q32SGkb/Q9FpUY1UlAu1DH9T7j++gZ0lHjnm4OyH2vCI7l7Q==}
-    cpu: [x64]
     os: [darwin]
 
   '@rollup/rollup-darwin-x64@4.44.0':
@@ -2190,12 +2180,6 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-arm64-gnu@4.34.9':
-    resolution: {integrity: sha512-6TZjPHjKZUQKmVKMUowF3ewHxctrRR09eYyvT5eFv8w/fXarEra83A2mHTVJLA5xU91aCNOUnM+DWFMSbQ0Nxw==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
   '@rollup/rollup-linux-arm64-gnu@4.44.0':
     resolution: {integrity: sha512-ZTR2mxBHb4tK4wGf9b8SYg0Y6KQPjGpR4UWwTFdnmjB4qRtoATZ5dWn3KsDwGa5Z2ZBOE7K52L36J9LueKBdOQ==}
     cpu: [arm64]
@@ -2207,12 +2191,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
-
-  '@rollup/rollup-linux-arm64-musl@4.34.9':
-    resolution: {integrity: sha512-LD2fytxZJZ6xzOKnMbIpgzFOuIKlxVOpiMAXawsAZ2mHBPEYOnLRK5TTEsID6z4eM23DuO88X0Tq1mErHMVq0A==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-musl@4.44.0':
     resolution: {integrity: sha512-GFWfAhVhWGd4r6UxmnKRTBwP1qmModHtd5gkraeW2G490BpFOZkFtem8yuX2NyafIP/mGpRJgTJ2PwohQkUY/Q==}
@@ -2268,12 +2246,6 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-x64-gnu@4.34.9':
-    resolution: {integrity: sha512-FwBHNSOjUTQLP4MG7y6rR6qbGw4MFeQnIBrMe161QGaQoBQLqSUEKlHIiVgF3g/mb3lxlxzJOpIBhaP+C+KP2A==}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
   '@rollup/rollup-linux-x64-gnu@4.44.0':
     resolution: {integrity: sha512-iUVJc3c0o8l9Sa/qlDL2Z9UP92UZZW1+EmQ4xfjTc1akr0iUFZNfxrXJ/R1T90h/ILm9iXEY6+iPrmYB3pXKjw==}
     cpu: [x64]
@@ -2285,12 +2257,6 @@ packages:
     cpu: [x64]
     os: [linux]
     libc: [glibc]
-
-  '@rollup/rollup-linux-x64-musl@4.34.9':
-    resolution: {integrity: sha512-cYRpV4650z2I3/s6+5/LONkjIz8MBeqrk+vPXV10ORBnshpn8S32bPqQ2Utv39jCiDcO2eJTuSlPXpnvmaIgRA==}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-x64-musl@4.44.0':
     resolution: {integrity: sha512-PQUobbhLTQT5yz/SPg116VJBgz+XOtXt8D1ck+sfJJhuEsMj2jSej5yTdp8CvWBSceu+WW+ibVL6dm0ptG5fcA==}
@@ -2314,11 +2280,6 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
-  '@rollup/rollup-win32-arm64-msvc@4.34.9':
-    resolution: {integrity: sha512-z4mQK9dAN6byRA/vsSgQiPeuO63wdiDxZ9yg9iyX2QTzKuQM7T4xlBoeUP/J8uiFkqxkcWndWi+W7bXdPbt27Q==}
-    cpu: [arm64]
-    os: [win32]
-
   '@rollup/rollup-win32-arm64-msvc@4.44.0':
     resolution: {integrity: sha512-M0CpcHf8TWn+4oTxJfh7LQuTuaYeXGbk0eageVjQCKzYLsajWS/lFC94qlRqOlyC2KvRT90ZrfXULYmukeIy7w==}
     cpu: [arm64]
@@ -2336,11 +2297,6 @@ packages:
 
   '@rollup/rollup-win32-x64-gnu@4.62.2':
     resolution: {integrity: sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==}
-    cpu: [x64]
-    os: [win32]
-
-  '@rollup/rollup-win32-x64-msvc@4.34.9':
-    resolution: {integrity: sha512-AyleYRPU7+rgkMWbEh71fQlrzRfeP6SyMnRf9XX4fCdDPAJumdSBqYEcWPMzVQ4ScAl7E4oFfK0GUVn77xSwbw==}
     cpu: [x64]
     os: [win32]
 
@@ -2382,20 +2338,15 @@ packages:
   '@sinonjs/fake-timers@10.3.0':
     resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
 
-  '@stencil/core@4.43.0':
-    resolution: {integrity: sha512-6Uj2Z3lzLuufYAE7asZ6NLKgSwsB9uxl84Eh34PASnUjfj32GkrP4DtKK7fNeh1WFGGyffsTDka3gwtl+4reUg==}
-    engines: {node: '>=16.0.0', npm: '>=7.10.0'}
-    hasBin: true
-
   '@stencil/core@4.43.5':
     resolution: {integrity: sha512-cgWD+GeuvJpTe1WQn40p02+BJ2j0j1YJ17GdkF2qKIQ23s2e3Zivq5yISXS3dcuV6oUJFN93jprdk+nk/sq99Q==}
     engines: {node: '>=16.0.0', npm: '>=7.10.0'}
     hasBin: true
 
-  '@stencil/react-output-target@1.5.3':
-    resolution: {integrity: sha512-TZzgbd48+HsfjyXtT4SZfX6LIcEuFNY9hpSYuxJTpglIXfUzc3dAr1vc8aIbrd2qVinwaXFzkwP+7rRiNq1uIA==}
+  '@stencil/react-output-target@1.6.0':
+    resolution: {integrity: sha512-YOv+V3zXjzaSnaTTr7xC8ZDr3vQTmXOTLPaUBYB3g+3I3vXRhS409Iom+TtFUEjx3bvE9XX2qhPhXTQhpUeKSw==}
     peerDependencies:
-      '@stencil/core': '>=3 || >= 4.0.0-beta.0 || >= 4.0.0'
+      '@stencil/core': '>=3 || >=4.0.0 || ^5.0.0 || >=5.0.0-alpha.0 <5.0.0-next.0'
       react: ^18 || ^19
       react-dom: ^18 || ^19
 
@@ -2405,10 +2356,10 @@ packages:
     peerDependencies:
       '@stencil/core': '>=2.0.0 || >=3.0.0-beta.0 || >= 4.0.0-beta.0 || >= 4.0.0'
 
-  '@stencil/vue-output-target@0.13.2':
-    resolution: {integrity: sha512-mPpT39f+0Y7KrJRKSN6BTWR5fIq1+EMgPG/IZeR3H6d4LaQRnuMs+z4W12b4nuIyUpol+uTSSVOGfOqJKie6rQ==}
+  '@stencil/vue-output-target@0.14.0':
+    resolution: {integrity: sha512-8ExNnjb+yriTU/8qgWZaOW1E5gppU8fQiZ7g5NDC8w05dCtYeHW3gZ6tV8WGjIyEMERG0XwVt6b63kubWG22wA==}
     peerDependencies:
-      '@stencil/core': '>=2.0.0 || >=3 || >= 4.0.0-beta.0 || >= 4.0.0'
+      '@stencil/core': '>=2.0.0 || >=3 || >=4.0.0 || ^5.0.0 || >=5.0.0-alpha.0 <5.0.0-next.0'
       vue: ^3.4.38
       vue-router: ^4.5.0 || ^5.0.0
     peerDependenciesMeta:
@@ -3742,8 +3693,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.4.7:
-    resolution: {integrity: sha512-2jBxDJY4RR06tQNy4w5FlFH7kfxsQZlufd0sbv+chfHCxeJwrFw2baUDsSwvBISD4K4RDbd0PTfy3uNXsR6siA==}
+  dompurify@3.4.11:
+    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
 
   domutils@2.8.0:
     resolution: {integrity: sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==}
@@ -8348,9 +8299,9 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@ionic/core@8.8.8':
+  '@ionic/core@8.8.13':
     dependencies:
-      '@stencil/core': 4.43.0
+      '@stencil/core': 4.43.5
       ionicons: 8.0.13
       tslib: 2.8.1
 
@@ -8991,16 +8942,10 @@ snapshots:
   '@rollup/rollup-android-arm64@4.62.2':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.34.9':
-    optional: true
-
   '@rollup/rollup-darwin-arm64@4.44.0':
     optional: true
 
   '@rollup/rollup-darwin-arm64@4.62.2':
-    optional: true
-
-  '@rollup/rollup-darwin-x64@4.34.9':
     optional: true
 
   '@rollup/rollup-darwin-x64@4.44.0':
@@ -9021,16 +8966,10 @@ snapshots:
   '@rollup/rollup-linux-arm-musleabihf@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.34.9':
-    optional: true
-
   '@rollup/rollup-linux-arm64-gnu@4.44.0':
     optional: true
 
   '@rollup/rollup-linux-arm64-gnu@4.62.2':
-    optional: true
-
-  '@rollup/rollup-linux-arm64-musl@4.34.9':
     optional: true
 
   '@rollup/rollup-linux-arm64-musl@4.44.0':
@@ -9060,16 +8999,10 @@ snapshots:
   '@rollup/rollup-linux-s390x-gnu@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.34.9':
-    optional: true
-
   '@rollup/rollup-linux-x64-gnu@4.44.0':
     optional: true
 
   '@rollup/rollup-linux-x64-gnu@4.62.2':
-    optional: true
-
-  '@rollup/rollup-linux-x64-musl@4.34.9':
     optional: true
 
   '@rollup/rollup-linux-x64-musl@4.44.0':
@@ -9084,9 +9017,6 @@ snapshots:
   '@rollup/rollup-openharmony-arm64@4.62.2':
     optional: true
 
-  '@rollup/rollup-win32-arm64-msvc@4.34.9':
-    optional: true
-
   '@rollup/rollup-win32-arm64-msvc@4.44.0':
     optional: true
 
@@ -9097,9 +9027,6 @@ snapshots:
     optional: true
 
   '@rollup/rollup-win32-x64-gnu@4.62.2':
-    optional: true
-
-  '@rollup/rollup-win32-x64-msvc@4.34.9':
     optional: true
 
   '@rollup/rollup-win32-x64-msvc@4.44.0':
@@ -9130,17 +9057,6 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
-  '@stencil/core@4.43.0':
-    optionalDependencies:
-      '@rollup/rollup-darwin-arm64': 4.34.9
-      '@rollup/rollup-darwin-x64': 4.34.9
-      '@rollup/rollup-linux-arm64-gnu': 4.34.9
-      '@rollup/rollup-linux-arm64-musl': 4.34.9
-      '@rollup/rollup-linux-x64-gnu': 4.34.9
-      '@rollup/rollup-linux-x64-musl': 4.34.9
-      '@rollup/rollup-win32-arm64-msvc': 4.34.9
-      '@rollup/rollup-win32-x64-msvc': 4.34.9
-
   '@stencil/core@4.43.5':
     optionalDependencies:
       '@rollup/rollup-darwin-arm64': 4.44.0
@@ -9152,7 +9068,7 @@ snapshots:
       '@rollup/rollup-win32-arm64-msvc': 4.44.0
       '@rollup/rollup-win32-x64-msvc': 4.44.0
 
-  '@stencil/react-output-target@1.5.3(@stencil/core@4.43.5)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@stencil/react-output-target@1.6.0(@stencil/core@4.43.5)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@lit/react': 1.0.8(@types/react@19.2.17)
       '@stencil/core': 4.43.5
@@ -9169,14 +9085,16 @@ snapshots:
       '@stencil/core': 4.43.5
       sass-embedded: 1.99.0
 
-  '@stencil/vue-output-target@0.13.2(@stencil/core@4.43.5)(vue@3.5.35(typescript@6.0.3))':
+  '@stencil/vue-output-target@0.14.0(@stencil/core@4.43.5)(vue@3.5.35(typescript@6.0.3))':
     dependencies:
+      ts-morph: 28.0.0
       vue: 3.5.35(typescript@6.0.3)
     optionalDependencies:
       '@stencil/core': 4.43.5
 
-  '@stencil/vue-output-target@0.13.2(@stencil/core@4.43.5)(vue@3.5.39(typescript@6.0.3))':
+  '@stencil/vue-output-target@0.14.0(@stencil/core@4.43.5)(vue@3.5.39(typescript@6.0.3))':
     dependencies:
+      ts-morph: 28.0.0
       vue: 3.5.39(typescript@6.0.3)
     optionalDependencies:
       '@stencil/core': 4.43.5
@@ -10705,7 +10623,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.4.7:
+  dompurify@3.4.11:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 


### PR DESCRIPTION
Production dependency bumps for the design-system packages. **Stacked on #858** (the SSR barrel fix) — merge #858 first, then this rebases cleanly.

## Updates

| Package | From | To | Scope |
|---|---|---|---|
| `@ionic/core` | 8.8.5 | 8.8.13 | prod (bundled) |
| `dompurify` | 3.4.2 | 3.4.11 | prod (runtime) |
| `@stencil/react-output-target` | 1.5.3 | 1.6.0 | prod (core, react) |
| `@stencil/vue-output-target` | 0.13.2 | 0.14.0 | prod (core, vue) |

## Security

Clears the **runtime dompurify advisories** (GHSA-vxr8-fq34-vvx9, GHSA-gvmj-g25r-r7wr, and the `ALLOWED_ATTR` pollution advisory) via the direct bump to 3.4.11.

## Breaking change handled — `@ionic/core` datetime

Ionic 8.8.13 tightened `ion-datetime`'s `FormatOptions` to a union that requires at least one of `date`/`time` (it can no longer be an empty object). Our `formatOptions` prop was typed with both optional, which no longer type-checks. Fixed by typing the prop with Ionic's own exported `FormatOptions` union (`fix(core)` commit). The default value is unchanged, so all sensible consumer usage is preserved — only the empty-object case (always nonsensical for Ionic) is now disallowed.

## Verification (Node 22, pnpm 10.28.2, `--frozen-lockfile`)

- `pnpm run build` (core, react, vue) → green
- `pnpm run test:ci` → green (core 241, react 4, vue 4)
- **Generated-output baseline diff vs `main`:**
  - Vue wrappers — **byte-identical** (0.14.0 codegen unchanged)
  - React wrappers — all `atom-*` wrappers **byte-identical**; only additive `components.server.ts` barrel (excluded from SSR barrel, see #858)
  - Core `dist` — changes confined to Ionic 8.8.13 internals, the dompurify chunk, and the datetime type-metadata; no change to our component API surface
- **Runtime smoke (Playwright, web-components Storybook):** datetime calendar renders; select overlay opens and renders options; modal overlay opens (teleport intact); select play-function test passes

## Deferred majors (see tracking task)

- `jest`/`jest-cli`/`@types/jest` 30 — **blocked**: `@stencil/core` 4.43.5 requires Jest 29
- `@babel/*` 8 — needs dedicated Storybook-build verification
- `nx`/`@nx/workspace` 23, `pnpm` 11 — coordination majors (build tooling / package manager)
