### PR TITLE
fix(modal): cap height and pin header/footer on tall content

### DIFF
--- a/packages/core/src/components/modal/modal.scss
+++ b/packages/core/src/components/modal/modal.scss
@@ -25,6 +25,13 @@
     padding: var(--spacing-large);
     padding-top: 0;
 
+    // Content is the only scroll container once ion-modal::part(content) is capped (see below);
+    // keeping this as auto would silently activate a nested scrollbar if this element ever gets
+    // an explicit height.
+    @include above('small') {
+      overflow-y: visible;
+    }
+
     &--divided {
       border-bottom: 1px solid var(--color-neutral-light-3);
       border-top: 1px solid var(--color-neutral-light-3);
@@ -41,7 +48,7 @@
 
     // Pins the footer while the content below scrolls (see ion-modal::part(content)).
     @include above('small') {
-      background: var(--background);
+      background: var(--background, var(--color-neutral-white));
       bottom: 0;
       position: sticky;
       z-index: var(--zindex-1);
@@ -56,7 +63,7 @@
 
     // Pins the header while the content below scrolls (see ion-modal::part(content)).
     @include above('small') {
-      background: var(--background);
+      background: var(--background, var(--color-neutral-white));
       position: sticky;
       top: 0;
       z-index: var(--zindex-1);
@@ -114,6 +121,10 @@ ion-modal::part(content) {
   @include above('small') {
     max-height: 90vh;
     overflow-y: auto;
+
+    // Reserves space so a keyboard-focused element near the top/bottom isn't hidden behind the
+    // sticky header/footer, which native focus scrolling doesn't otherwise account for.
+    scroll-padding-block: var(--spacing-xxxxlarge);
   }
 
   @include below('small') {

--- a/packages/core/src/components/modal/modal.scss
+++ b/packages/core/src/components/modal/modal.scss
@@ -38,6 +38,14 @@
     gap: var(--spacing-medium);
     justify-content: flex-end;
     padding: var(--spacing-large);
+
+    // Pins the footer while the content below scrolls (see ion-modal::part(content)).
+    @include above('small') {
+      background: var(--background);
+      bottom: 0;
+      position: sticky;
+      z-index: var(--zindex-1);
+    }
   }
 
   &__header {
@@ -45,6 +53,14 @@
     padding: var(--spacing-large);
     padding-right: var(--atom-modal-padding-header);
     position: relative;
+
+    // Pins the header while the content below scrolls (see ion-modal::part(content)).
+    @include above('small') {
+      background: var(--background);
+      position: sticky;
+      top: 0;
+      z-index: var(--zindex-1);
+    }
   }
 
   &__icon-type {
@@ -91,6 +107,14 @@
 ion-modal::part(content) {
   --border-radius: 8px;
   height: auto;
+
+  // With no max-height, content taller than the viewport just overflows past both edges instead
+  // of scrolling internally, pushing the header/footer off-screen. Capping it and letting it
+  // scroll (paired with the header/footer `position: sticky` above) fixes that.
+  @include above('small') {
+    max-height: 90vh;
+    overflow-y: auto;
+  }
 
   @include below('small') {
     --border-radius: 0;


### PR DESCRIPTION

## Summary

`ion-modal::part(content)` (the actual dialog box Ionic renders) had `height: auto` with no `max-height`. On tablet/desktop, a modal whose content is taller than the viewport just overflows past both edges instead of scrolling internally - the header gets pushed above the top of the screen and the footer below the bottom, both effectively invisible.

Fix: cap `part(content)` at `max-height: 90vh` and make it the scroll container (`overflow-y: auto`), then pin `.atom-modal__header`/`.atom-modal__footer` with `position: sticky` so they stay visible while the middle content scrolls underneath them.

This intentionally does **not** touch Ionic's own internal `.ion-page` delegate-host wrapper or `.atom-modal__content`'s sizing - an earlier attempt using `display: flex` on the wrapper needed to fight `.ion-page`'s `height: 100%` (which resolves to `auto` against an `auto`-height ancestor even once `max-height` clamps it - a CSS percentage-vs-auto-parent quirk). `position: sticky` sidesteps that entirely: it only needs a scrolling ancestor, regardless of how intervening elements resolve their own height.

Scoped to `@include above('small')` only - the existing mobile fullscreen modal (`@include below('small')`, `height: 100%`) is untouched and doesn't have this bug (its containing block already has a definite height).

## Evidences

No visual snapshot from this environment. Verified computed layout with Playwright against the real compiled `ion-modal`/`atom-modal` web components (not jsdom, which doesn't do real CSS layout) at multiple viewports:

- Desktop, short viewport (800px) + content taller than the viewport: before the fix, header top was at `-73px` (above viewport) and footer bottom at `873px` (below viewport) - both invisible. After the fix, both stay fully within the viewport at every scroll position, including scrolled to the max (`scrollTop` at its maximum), and the content between them gets a real scrollbar.
- Desktop, tall viewport + short content: modal still shrinks to fit content (height well under the `90vh` cap) - no regression for the common case.
- Mobile viewport (<768px): `max-height: none`, `overflow: hidden`, `height` = 100% of viewport, no `position: sticky` applied - fullscreen behavior untouched.