### PR TITLE
fix(core): resolve hydrate to a browser no-op in client builds

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,7 +28,7 @@
     "core.css"
   ],
   "scripts": {
-    "build": "stencil build && npx copyfiles --flat ./dist/core/core.css ./ && node -e \"require('fs').writeFileSync('dist/components/package.json', JSON.stringify({ type: 'module' }, null, 2) + '\\n')\" && node scripts/ssr-smoke.mjs",
+    "build": "stencil build && npx copyfiles --flat ./dist/core/core.css ./ && node -e \"require('fs').writeFileSync('dist/components/package.json', JSON.stringify({ type: 'module' }, null, 2) + '\\n')\" && node scripts/write-hydrate-browser-stub.mjs && node scripts/ssr-smoke.mjs",
     "start": "stencil build --watch",
     "test": "stencil test --spec",
     "test:ci": "stencil test --spec --coverage --no-cache --updateSnapshot --ci",
@@ -51,6 +51,7 @@
     "./dist/*": "./dist/*",
     "./hydrate": {
       "types": "./hydrate/index.d.ts",
+      "browser": "./hydrate/index.browser.mjs",
       "import": "./hydrate/index.mjs",
       "require": "./hydrate/index.js"
     },

--- a/packages/core/scripts/hydrate-browser-stub.mjs
+++ b/packages/core/scripts/hydrate-browser-stub.mjs
@@ -1,0 +1,21 @@
+import { writeFileSync } from 'fs'
+
+const THROW_MESSAGE =
+  '@juntossomosmais/atomium/hydrate is server-only and cannot run in the browser'
+
+export function buildHydrateBrowserStub(exportNames) {
+  const exportsBlock = exportNames
+    .map((name) => `export const ${name} = serverOnly`)
+    .join('\n')
+
+  return `/* auto-generated — browser no-op for the Node-only hydrate app. See scripts/write-hydrate-browser-stub.mjs */
+const serverOnly = () => {
+  throw new Error('${THROW_MESSAGE}')
+}
+${exportsBlock}
+`
+}
+
+export function writeHydrateBrowserStub(exportNames, targetPath, writeFile = writeFileSync) {
+  writeFile(targetPath, buildHydrateBrowserStub(exportNames))
+}

--- a/packages/core/scripts/hydrate-browser-stub.spec.ts
+++ b/packages/core/scripts/hydrate-browser-stub.spec.ts
@@ -1,0 +1,67 @@
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+import {
+  buildHydrateBrowserStub,
+  writeHydrateBrowserStub,
+} from './hydrate-browser-stub.mjs'
+
+describe('buildHydrateBrowserStub', () => {
+  it('exports every given name as a throwing serverOnly function', () => {
+    const stub = buildHydrateBrowserStub(['renderToString', 'streamToString'])
+
+    expect(stub).toContain('export const renderToString = serverOnly')
+    expect(stub).toContain('export const streamToString = serverOnly')
+    expect(stub).toContain(
+      "throw new Error('@juntossomosmais/atomium/hydrate is server-only and cannot run in the browser')"
+    )
+  })
+
+  it('exports exactly the given names — no more, no fewer, so it can never silently drift from the real hydrate module', () => {
+    const names = ['renderToString', 'hydrateDocument', 'transformTag']
+    const stub = buildHydrateBrowserStub(names)
+
+    const exported = [...stub.matchAll(/export const (\w+) = serverOnly/g)].map(
+      (match) => match[1]
+    )
+
+    expect(exported.sort()).toEqual([...names].sort())
+  })
+
+  it('contains no import or require, so no Node builtin (e.g. stream) can be pulled into a browser bundle through it', () => {
+    const stub = buildHydrateBrowserStub(['renderToString'])
+
+    expect(stub).not.toMatch(/\bimport\b/)
+    expect(stub).not.toMatch(/\brequire\s*\(/)
+  })
+})
+
+describe('writeHydrateBrowserStub', () => {
+  it('writes the generated stub to the given path', () => {
+    const writeFile = jest.fn()
+
+    writeHydrateBrowserStub(
+      ['renderToString'],
+      '/tmp/hydrate/index.browser.mjs',
+      writeFile
+    )
+
+    expect(writeFile).toHaveBeenCalledWith(
+      '/tmp/hydrate/index.browser.mjs',
+      buildHydrateBrowserStub(['renderToString'])
+    )
+  })
+})
+
+describe('package.json ./hydrate export map', () => {
+  it('declares a browser condition distinct from the server targets, so client bundlers never resolve the Node-only hydrate module', () => {
+    const pkg = JSON.parse(
+      readFileSync(resolve(__dirname, '../package.json'), 'utf-8')
+    )
+    const hydrateExport = pkg.exports['./hydrate']
+
+    expect(hydrateExport.browser).toBeDefined()
+    expect(hydrateExport.browser).not.toBe(hydrateExport.import)
+    expect(hydrateExport.browser).not.toBe(hydrateExport.require)
+  })
+})

--- a/packages/core/scripts/write-hydrate-browser-stub.mjs
+++ b/packages/core/scripts/write-hydrate-browser-stub.mjs
@@ -14,31 +14,25 @@
  * These functions are never invoked in a browser (the branch that uses them only
  * runs when `globalThis.window` is falsy), so they throw to surface any misuse.
  *
+ * Export names are derived from the real hydrate module (not hand-duplicated),
+ * so this stub can never drift from whatever Stencil generates.
+ *
  * Runs as part of `npm run build`, after `stencil build` has generated `hydrate/`.
  */
-import { writeFileSync } from 'fs'
 import { fileURLToPath } from 'url'
 import { dirname, resolve } from 'path'
 
-const target = resolve(
+import { writeHydrateBrowserStub } from './hydrate-browser-stub.mjs'
+import * as realHydrateModule from '../hydrate/index.mjs'
+
+const exportNames = Object.keys(realHydrateModule).sort()
+const targetPath = resolve(
   dirname(fileURLToPath(import.meta.url)),
   '../hydrate/index.browser.mjs',
 )
 
-const stub = `/* auto-generated — browser no-op for the Node-only hydrate app. See scripts/write-hydrate-browser-stub.mjs */
-const serverOnly = () => {
-  throw new Error('@juntossomosmais/atomium/hydrate is server-only and cannot run in the browser')
-}
-export const renderToString = serverOnly
-export const streamToString = serverOnly
-export const hydrateDocument = serverOnly
-export const createWindowFromHtml = serverOnly
-export const serializeDocumentToString = serverOnly
-export const serializeProperty = serverOnly
-export const deserializeProperty = serverOnly
-export const setTagTransformer = serverOnly
-export const transformTag = serverOnly
-`
+writeHydrateBrowserStub(exportNames, targetPath)
 
-writeFileSync(target, stub)
-console.log('Wrote hydrate/index.browser.mjs (browser no-op)')
+console.log(
+  `Wrote hydrate/index.browser.mjs (browser no-op) mirroring ${exportNames.length} export(s): ${exportNames.join(', ')}`,
+)

--- a/packages/core/scripts/write-hydrate-browser-stub.mjs
+++ b/packages/core/scripts/write-hydrate-browser-stub.mjs
@@ -1,0 +1,44 @@
+/**
+ * Writes `hydrate/index.browser.mjs`, a browser-safe no-op counterpart to the
+ * Node-only hydrate app produced by the `dist-hydrate-script` output target.
+ *
+ * Why this exists: the Vue/React proxies reference the hydrate module in their
+ * server-only branch as `import('@juntossomosmais/atomium/hydrate')`. Bundlers
+ * statically bundle every `import()` regardless of which branch runs at runtime,
+ * so a client-only consumer (SPA / `ssr: false`) ends up pulling the real
+ * hydrate app, which imports Node's `stream` and breaks the browser build
+ * (`"Readable" is not exported by "__vite-browser-external"`).
+ *
+ * The `browser` export condition on `./hydrate` (see package.json) points here,
+ * so client builds resolve this stub while server builds keep the real module.
+ * These functions are never invoked in a browser (the branch that uses them only
+ * runs when `globalThis.window` is falsy), so they throw to surface any misuse.
+ *
+ * Runs as part of `npm run build`, after `stencil build` has generated `hydrate/`.
+ */
+import { writeFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+import { dirname, resolve } from 'path'
+
+const target = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  '../hydrate/index.browser.mjs',
+)
+
+const stub = `/* auto-generated — browser no-op for the Node-only hydrate app. See scripts/write-hydrate-browser-stub.mjs */
+const serverOnly = () => {
+  throw new Error('@juntossomosmais/atomium/hydrate is server-only and cannot run in the browser')
+}
+export const renderToString = serverOnly
+export const streamToString = serverOnly
+export const hydrateDocument = serverOnly
+export const createWindowFromHtml = serverOnly
+export const serializeDocumentToString = serverOnly
+export const serializeProperty = serverOnly
+export const deserializeProperty = serverOnly
+export const setTagTransformer = serverOnly
+export const transformTag = serverOnly
+`
+
+writeFileSync(target, stub)
+console.log('Wrote hydrate/index.browser.mjs (browser no-op)')


### PR DESCRIPTION
## Problem

Enabling SSR on the Vue/React output targets (`hydrateModule`, added in #853) made every generated proxy reference the Node-only hydrate app in its server-only branch:

```js
export const AtomModal = globalThis.window
  ? defineContainer('atom-modal', ...)                            // browser — never touches hydrate
  : defineStencilSSRComponent({ hydrateModule: import('@juntossomosmais/atomium/hydrate') })  // server only
```

Bundlers statically bundle **every** `import()`, regardless of which branch runs at runtime. So a **client-only** consumer (a Vite SPA, or Nuxt with `ssr: false`) ends up pulling `hydrate/index.mjs`, which does `import { Readable } from 'stream'`, and the browser build fails:

```
RollupError: node_modules/@juntossomosmais/atomium/hydrate/index.mjs (1:9):
"Readable" is not exported by "__vite-browser-external"
```

## Fix

Add a `browser` export condition on `./hydrate` pointing to a generated no-op stub. Vite/webpack/Rollup/esbuild resolve `browser` **only in client builds** and ignore it in server builds:

- **client builds** (SPA / `ssr: false`, and the client half of an SSR app) → resolve the empty stub → no `stream` import → build passes.
- **server builds** (Nitro/Node) → keep `hydrate/index.mjs` → SSR still works.

The stub mirrors the hydrate public API as `serverOnly` functions that throw, so any accidental browser-side use surfaces loudly. It's never invoked in a browser (its branch only runs when `globalThis.window` is falsy).

### Changes
- `packages/core/scripts/write-hydrate-browser-stub.mjs` — generates `hydrate/index.browser.mjs` post-build.
- `packages/core/package.json` — `browser` condition on `./hydrate` + wire the script into `build`.

## Verification
- `nx build @juntossomosmais/atomium` ✅ — build finished; `browser` condition survives the stencil build (not rewritten).
- `ssr-smoke.mjs` (renders all components via the **real** hydrate in Node) ✅ 25/25 — server SSR intact.

## Notes
Stencil's SSR docs assume a full SSR framework and don't cover keeping the Node hydrate out of a client-only bundle. The `browser` export condition is the standard package-level convention for this. Worth reporting the gap upstream in `stencil-ds-output-targets`.