### PR TITLE
fix(core): dismiss body-level ion-popover on scroll without ion-app

### DIFF
--- a/packages/core/src/components/select/select.tsx
+++ b/packages/core/src/components/select/select.tsx
@@ -213,7 +213,7 @@ export class AtomSelect {
           onIonFocus={this.handleFocus}
           onIonCancel={this.handleCancel}
           interfaceOptions={{
-            cssClass: `atom-select__popover`,
+            cssClass: 'atom-select__popover atomium-popover',
           }}
         >
           {this.options.map((option) => (

--- a/packages/core/src/global/global.spec.ts
+++ b/packages/core/src/global/global.spec.ts
@@ -1,0 +1,235 @@
+const importGlobalFresh = (): void => {
+  jest.isolateModules(() => {
+    require('./global')
+  })
+}
+
+const waitForRaf = (): Promise<void> =>
+  new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
+
+const flushMicrotasks = (): Promise<void> => Promise.resolve()
+
+describe('global', () => {
+  const createPopoverElement = (isAtomium = true) => {
+    const element = document.createElement('ion-popover')
+
+    if (isAtomium) element.classList.add('atomium-popover')
+
+    document.body.appendChild(element)
+
+    return element
+  }
+
+  const present = (element: Element) =>
+    element.dispatchEvent(
+      new Event('ionPopoverDidPresent', { bubbles: true, composed: true })
+    )
+
+  const dismiss = (element: Element) =>
+    element.dispatchEvent(
+      new Event('ionPopoverDidDismiss', { bubbles: true, composed: true })
+    )
+
+  const mockIonApp = (isPresent: boolean) =>
+    jest
+      .spyOn(document, 'querySelector')
+      .mockReturnValue(isPresent ? document.createElement('ion-app') : null)
+
+  // `:scope` is unsupported by Stencil's mock-doc, so the body-level query is
+  // stubbed. `popovers` drives what the module sees as currently open.
+  const mockBodyPopovers = (popovers: { dismiss: jest.Mock }[]) =>
+    jest
+      .spyOn(document.body, 'querySelectorAll')
+      .mockReturnValue(popovers as unknown as NodeListOf<HTMLIonPopoverElement>)
+
+  const createPopoverMock = () => ({
+    dismiss: jest.fn().mockResolvedValue(true),
+  })
+
+  beforeEach(() => {
+    delete window.__atomiumDismissPopoversOnScroll
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+    document.body.innerHTML = ''
+  })
+
+  it('should not listen to scroll until a popover is presented', () => {
+    const addEventListenerSpy = jest.spyOn(window, 'addEventListener')
+
+    importGlobalFresh()
+
+    const scrollListenerCalls = addEventListenerSpy.mock.calls.filter(
+      ([eventName]) => eventName === 'scroll'
+    )
+
+    expect(scrollListenerCalls).toHaveLength(0)
+  })
+
+  it('should listen to scroll in the capture phase once a popover is presented', () => {
+    const addEventListenerSpy = jest.spyOn(window, 'addEventListener')
+
+    importGlobalFresh()
+    present(createPopoverElement())
+
+    expect(addEventListenerSpy).toHaveBeenCalledWith(
+      'scroll',
+      expect.any(Function),
+      { capture: true, passive: true }
+    )
+  })
+
+  it('should ignore popovers that do not belong to Atomium', () => {
+    const addEventListenerSpy = jest.spyOn(window, 'addEventListener')
+
+    importGlobalFresh()
+    present(createPopoverElement(false))
+
+    const scrollListenerCalls = addEventListenerSpy.mock.calls.filter(
+      ([eventName]) => eventName === 'scroll'
+    )
+
+    expect(scrollListenerCalls).toHaveLength(0)
+  })
+
+  it('should dismiss body-level popovers on scroll when there is no ion-app', async () => {
+    mockIonApp(false)
+
+    const popover = createPopoverMock()
+
+    mockBodyPopovers([popover])
+    importGlobalFresh()
+    present(createPopoverElement())
+    window.dispatchEvent(new Event('scroll'))
+    await waitForRaf()
+
+    expect(popover.dismiss).toHaveBeenCalledTimes(1)
+  })
+
+  it('should not dismiss popovers when ion-app is present', async () => {
+    mockIonApp(true)
+
+    const popover = createPopoverMock()
+
+    mockBodyPopovers([popover])
+    importGlobalFresh()
+    present(createPopoverElement())
+    window.dispatchEvent(new Event('scroll'))
+    await waitForRaf()
+
+    expect(popover.dismiss).not.toHaveBeenCalled()
+  })
+
+  it('should dismiss only once per frame when scroll fires repeatedly', async () => {
+    mockIonApp(false)
+
+    const popover = createPopoverMock()
+
+    mockBodyPopovers([popover])
+    importGlobalFresh()
+    present(createPopoverElement())
+    window.dispatchEvent(new Event('scroll'))
+    window.dispatchEvent(new Event('scroll'))
+    window.dispatchEvent(new Event('scroll'))
+    await waitForRaf()
+
+    expect(popover.dismiss).toHaveBeenCalledTimes(1)
+  })
+
+  it('should not dismiss a popover when the scroll comes from its own option list', async () => {
+    mockIonApp(false)
+
+    const popover = createPopoverMock()
+    const popoverElement = createPopoverElement()
+    const optionList = document.createElement('div')
+
+    popoverElement.appendChild(optionList)
+    mockBodyPopovers([popover])
+    importGlobalFresh()
+    present(popoverElement)
+    // `bubbles: true` is required to reach the window listener under Stencil's
+    // mock-doc, which does not implement capture-phase propagation. Real
+    // `scroll` events don't bubble — what matters here is that the handler
+    // sees an `event.target` living inside the popover.
+    optionList.dispatchEvent(new Event('scroll', { bubbles: true }))
+    await waitForRaf()
+
+    expect(popover.dismiss).not.toHaveBeenCalled()
+  })
+
+  it('should stop listening to scroll once the last popover is dismissed', async () => {
+    mockIonApp(false)
+
+    const popover = createPopoverMock()
+    const popoverElement = createPopoverElement()
+
+    mockBodyPopovers([popover])
+    importGlobalFresh()
+    present(popoverElement)
+
+    // Ionic detaches the element only after emitting `didDismiss`, so the
+    // module re-reads the DOM a microtask later — by then it is empty.
+    mockBodyPopovers([])
+    dismiss(popoverElement)
+    await flushMicrotasks()
+
+    // Re-stock the query so a *still attached* listener would have something
+    // to dismiss — otherwise this assertion would pass either way.
+    const reopened = createPopoverMock()
+
+    mockBodyPopovers([reopened])
+    window.dispatchEvent(new Event('scroll'))
+    await waitForRaf()
+
+    expect(reopened.dismiss).not.toHaveBeenCalled()
+  })
+
+  it('should keep listening while another popover is still open', async () => {
+    mockIonApp(false)
+
+    const popover = createPopoverMock()
+    const firstElement = createPopoverElement()
+    const secondElement = createPopoverElement()
+
+    mockBodyPopovers([popover])
+    importGlobalFresh()
+    present(firstElement)
+    present(secondElement)
+
+    dismiss(firstElement)
+    await flushMicrotasks()
+
+    window.dispatchEvent(new Event('scroll'))
+    await waitForRaf()
+
+    expect(popover.dismiss).toHaveBeenCalledTimes(1)
+  })
+
+  it('should register the scroll listener only once while a popover is open', () => {
+    const addEventListenerSpy = jest.spyOn(window, 'addEventListener')
+
+    importGlobalFresh()
+    present(createPopoverElement())
+    present(createPopoverElement())
+
+    const scrollListenerCalls = addEventListenerSpy.mock.calls.filter(
+      ([eventName]) => eventName === 'scroll'
+    )
+
+    expect(scrollListenerCalls).toHaveLength(1)
+  })
+
+  it('should register the popover listeners only once across repeated imports', () => {
+    const addEventListenerSpy = jest.spyOn(document, 'addEventListener')
+
+    importGlobalFresh()
+    importGlobalFresh()
+
+    const presentListenerCalls = addEventListenerSpy.mock.calls.filter(
+      ([eventName]) => eventName === 'ionPopoverDidPresent'
+    )
+
+    expect(presentListenerCalls).toHaveLength(1)
+  })
+})

--- a/packages/core/src/global/global.ts
+++ b/packages/core/src/global/global.ts
@@ -3,6 +3,12 @@ import '@ionic/core'
 // Polyfill need to make form.requestSubmit work in Safari < 16.
 import '../polyfills/form-request-submit.js'
 
+declare global {
+  interface Window {
+    __atomiumDismissPopoversOnScroll?: boolean
+  }
+}
+
 // Force Ionic's "md" mode. The dist-custom-elements output consumed by the
 // React wrappers never runs global scripts, so the mode resolver must be set
 // as a module side-effect here, otherwise Ionic-backed components render
@@ -19,6 +25,35 @@ if (typeof setMode === 'function') {
   forceMdMode()
 } else {
   queueMicrotask(forceMdMode)
+}
+
+// ion-select's popover interface (and any other Ionic overlay using
+// `interface="popover"`) teleports its content to `ion-app` on present so the
+// app root can reposition/dismiss it as the page scrolls. Hosts that don't
+// mount an `<ion-app>` (e.g. a Next.js app consuming Atomium components
+// directly) get the fallback teleport target instead: `document.body`
+// (see Ionic's `getAppRoot`). Nothing then dismisses the overlay on scroll,
+// so it stays pinned at the viewport coordinates where it opened and floats
+// over unrelated content as the page scrolls underneath it. Since there is
+// no `ion-app` to patch, dismiss any body-level popover here instead — this
+// module runs as a side effect on import, unlike `globalScript` below, which
+// the dist-custom-elements/React output target never invokes (see comment
+// above). Guarded so re-importing this module (multiple lazy chunks in the
+// legacy `dist` runtime) only ever registers one listener.
+if (typeof window !== 'undefined' && !window.__atomiumDismissPopoversOnScroll) {
+  window.__atomiumDismissPopoversOnScroll = true
+
+  window.addEventListener(
+    'scroll',
+    () => {
+      if (document.querySelector('ion-app')) return
+
+      document.body
+        .querySelectorAll(':scope > ion-popover')
+        .forEach((popover) => (popover as HTMLIonPopoverElement).dismiss())
+    },
+    { passive: true }
+  )
 }
 
 export default function globalScript() {

--- a/packages/core/src/global/global.ts
+++ b/packages/core/src/global/global.ts
@@ -39,21 +39,107 @@ if (typeof setMode === 'function') {
 // module runs as a side effect on import, unlike `globalScript` below, which
 // the dist-custom-elements/React output target never invokes (see comment
 // above). Guarded so re-importing this module (multiple lazy chunks in the
-// legacy `dist` runtime) only ever registers one listener.
+// legacy `dist` runtime) only ever registers one set of listeners.
 if (typeof window !== 'undefined' && !window.__atomiumDismissPopoversOnScroll) {
   window.__atomiumDismissPopoversOnScroll = true
 
-  window.addEventListener(
-    'scroll',
-    () => {
-      if (document.querySelector('ion-app')) return
+  // Only Atomium's own popovers are dismissed, so a host pairing Atomium with
+  // another Ionic-based library keeps control of its own overlays. The marker
+  // class is applied through `interfaceOptions.cssClass` (see select.tsx).
+  const ATOMIUM_POPOVER = 'ion-popover.atomium-popover'
+  const BODY_POPOVERS = `:scope > ${ATOMIUM_POPOVER}`
 
-      document.body
-        .querySelectorAll(':scope > ion-popover')
-        .forEach((popover) => (popover as HTMLIonPopoverElement).dismiss())
-    },
-    { passive: true }
-  )
+  // `capture: true` so scroll events from descendant `overflow:auto`
+  // containers are observed too — `scroll` doesn't bubble, but a capture
+  // listener on `window` still sees it during the capture phase.
+  const SCROLL_OPTIONS: AddEventListenerOptions = {
+    capture: true,
+    passive: true,
+  }
+
+  let scheduled = false
+  let lastScrollTarget: EventTarget | null = null
+  let isListening = false
+
+  const getBodyPopovers = () =>
+    document.body.querySelectorAll<HTMLIonPopoverElement>(BODY_POPOVERS)
+
+  // Duck-typed rather than `instanceof Element`: an event target can originate
+  // from another realm (an iframe's document), where `instanceof` is false for
+  // a genuine element. `window`/`document` targets correctly yield null.
+  const asElement = (target: EventTarget | null): Element | null =>
+    typeof (target as Element | null)?.matches === 'function'
+      ? (target as Element)
+      : null
+
+  // rAF-throttled so the DOM queries below run at most once per frame
+  // instead of on every `scroll` event fired during a gesture.
+  const dismissBodyPopoversOnScroll = (): void => {
+    scheduled = false
+
+    // Read and release: holding the reference past this frame would keep a
+    // detached node alive for the lifetime of the page.
+    const scrollTarget = lastScrollTarget
+
+    lastScrollTarget = null
+
+    if (document.querySelector('ion-app')) return
+
+    // A scroll whose target lives inside the popover itself (e.g. paging
+    // through a long select's option list) is the intended interaction, not
+    // a page scroll — dismissing here would close the list mid-scroll.
+    if (asElement(scrollTarget)?.closest(ATOMIUM_POPOVER)) return
+
+    getBodyPopovers().forEach((popover) => popover.dismiss().catch(() => {}))
+  }
+
+  const handleScroll = (event: Event): void => {
+    lastScrollTarget = event.target
+
+    if (scheduled) return
+
+    scheduled = true
+    requestAnimationFrame(dismissBodyPopoversOnScroll)
+  }
+
+  const startListening = (): void => {
+    if (isListening) return
+
+    isListening = true
+    window.addEventListener('scroll', handleScroll, SCROLL_OPTIONS)
+  }
+
+  const stopListening = (): void => {
+    if (!isListening) return
+
+    isListening = false
+    scheduled = false
+    lastScrollTarget = null
+    window.removeEventListener('scroll', handleScroll, SCROLL_OPTIONS)
+  }
+
+  const isAtomiumPopover = (target: EventTarget | null): boolean =>
+    asElement(target)?.matches(ATOMIUM_POPOVER) === true
+
+  // The scroll listener exists only while one of our popovers is open, so a
+  // page that never opens one pays nothing on scroll. `ionPopoverDidPresent`
+  // and `ionPopoverDidDismiss` both bubble and are composed, so `document`
+  // sees them wherever Ionic teleported the overlay to.
+  document.addEventListener('ionPopoverDidPresent', (event) => {
+    if (isAtomiumPopover(event.target)) startListening()
+  })
+
+  document.addEventListener('ionPopoverDidDismiss', (event) => {
+    if (!isAtomiumPopover(event.target)) return
+
+    // Ionic emits `didDismiss` before detaching the element, so the DOM is
+    // only authoritative one microtask later — the removal is synchronous
+    // after the emit. Re-querying (instead of counting opens) means a missed
+    // event can never leave the listener attached to a closed popover.
+    queueMicrotask(() => {
+      if (getBodyPopovers().length === 0) stopListening()
+    })
+  })
 }
 
 export default function globalScript() {


### PR DESCRIPTION
[Task](https://juntossomosmais.monday.com/boards/5337789717/pulses/12649333296)

## Summary

Fixes `atom-select`'s options popover staying pinned at fixed viewport coordinates and floating over unrelated page content while the user scrolls, instead of following its trigger or closing.

**Root cause**: `atom-select` renders `<ion-select interface="popover">`. On present, Ionic teleports the popover's content into `<ion-app>` — that's the element responsible for repositioning/dismissing overlays as the page scrolls. Any host that doesn't mount an `<ion-app>` root (e.g. a plain Next.js/React app consuming Atomium components directly, without the full Ionic framework shell) falls back to Ionic's default teleport target, `document.body`, which has no such wiring. The popover then just stays wherever it opened.

This is not specific to `atom-select`'s SSR/hydration setup — it reproduces identically whether the component is server-rendered or fully client-hydrated, and regardless of how it's consumed (direct JSX or wrapped in `styled()`). It's a gap in how `interface="popover"` behaves outside a full Ionic app shell.

**Fix**: `packages/core/src/global/global.ts` now registers a `window` scroll listener as a module-level side effect (so it also runs in the `dist-custom-elements`/React output target, which never invokes the exported `globalScript()` function — same pattern already used there for `forceMdMode`). The listener dismisses any `ion-popover` that's a direct child of `body`, and only when no `<ion-app>` is present, so it never interferes with a real Ionic app's own overlay handling.

Verified against the two `AtomSelect` consumption patterns in a downstream app (direct JSX and `styled(AtomSelect)`) — scrolling with the popover open now closes it instead of leaving it floating.

`pnpm test`: 246/246 passing, 29 suites.

## Evidences

https://github.com/user-attachments/assets/c8feacdb-b065-4f6f-bc89-b0ca070cff53



